### PR TITLE
Add `IPaletteReader` interface for loading environment palette data (bin/pal/*.cgp)

### DIFF
--- a/include/cgl/resources/palette_reader.h
+++ b/include/cgl/resources/palette_reader.h
@@ -1,0 +1,45 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2024-2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+#pragma once
+
+#include <memory>
+#include "cgl/core/results.h"
+#include "cgl/resources/resource_types.h"
+
+namespace cgl {
+
+struct Settings;
+
+class IPaletteReader {
+ public:
+    using Ptr = std::unique_ptr<IPaletteReader>;
+
+    struct CreateInfo {
+        const cgl::Settings*  pSettings;
+    };
+
+    static IPaletteReader::Ptr create(const CreateInfo& createInfo);
+
+    explicit IPaletteReader(const CreateInfo& createInfo)
+        : createInfo_(createInfo) {}
+
+    virtual ~IPaletteReader() = default;
+
+    const CreateInfo& createInfo() const noexcept { return createInfo_; }
+
+    // Try to open specific Graphic*_*.bin data but not read data yet.
+    virtual cgl::Results read(
+        cgl::EnvironmentPaletteTypes envPalette,
+        cgl::PaletteData256*         pPaletteData) = 0;
+
+ private:
+    const CreateInfo createInfo_;
+};
+
+}   // namespace cgl

--- a/include/cgl/resources/resource_types.h
+++ b/include/cgl/resources/resource_types.h
@@ -32,6 +32,25 @@ union PaletteData {
 
 using PaletteData256 = std::array<PaletteData, 256>;
 
+// EnvironmentPaletteTypes enum
+#define EnvironmentPaletteTypes_ENUM_LIST \
+    CGL_X(Daytime)                        \
+    CGL_X(Evening)                        \
+    CGL_X(Night)                          \
+    CGL_X(EarlyMorning)                   \
+    CGL_X(Unknown)                        \
+
+enum class EnvironmentPaletteTypes : uint8_t {
+#define CGL_X(name) name,
+    EnvironmentPaletteTypes_ENUM_LIST
+#undef CGL_X
+};
+
+struct EnvironmentPaletteResourcePath {
+    cgl::EnvironmentPaletteTypes paletteType;
+    std::string_view             paletteFilePath;
+};
+
 // -----------------------------------------------------------------------------
 // GraphicsResourceIndexTypes
 // -----------------------------------------------------------------------------

--- a/include/cgl/settings/settings.h
+++ b/include/cgl/settings/settings.h
@@ -13,6 +13,9 @@
 
 namespace cgl {
 
+enum class EnvironmentPaletteTypes : uint8_t;
+
+struct EnvironmentPaletteResourcePath;
 
 struct Settings {
     /**
@@ -27,6 +30,9 @@ struct Settings {
 
     const cgl::CrossGateResourcePaths& crossGateResourcePath(
         cgl::CrossGateVersion version) const noexcept;
+
+    const cgl::EnvironmentPaletteResourcePath& envPalettePath(
+        cgl::EnvironmentPaletteTypes paletteType) const noexcept;
 };
 
 }   // namespace cgl

--- a/include/cgl/utils/enum_string_helper.h
+++ b/include/cgl/utils/enum_string_helper.h
@@ -15,9 +15,11 @@ namespace cgl {
 enum class Results : uint32_t;
 enum class CrossGateVersion : uint8_t;
 enum class GraphicsResourceIndexTypes : uint8_t;
+enum class EnvironmentPaletteTypes : uint8_t;
 
 const char* GetString(const cgl::Results& type);
 const char* GetString(const cgl::CrossGateVersion& type);
 const char* GetString(const cgl::GraphicsResourceIndexTypes& type);
+const char* GetString(const cgl::EnvironmentPaletteTypes& type);
 
 }   // namespace cgl

--- a/src/resources/palette_reader.cpp
+++ b/src/resources/palette_reader.cpp
@@ -1,0 +1,166 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2024-2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+
+#include "cgl/settings/settings.h"
+#include "cgl/resources/palette_reader.h"
+#include "cgl/utils/enum_string_helper.h"
+#include "utils/file_utils.h"
+#include "utils/logger.h"
+
+using cgl::PaletteData;
+
+constexpr size_t MAX_PALETTE_COUNT = 256;
+constexpr size_t COLORS_IN_PALETTE_FILE = 236;
+constexpr size_t DEFAULT_PALETTE_OFFSET = 16;
+constexpr size_t PALETTE_FILE_SIZE = sizeof(cgl::PaletteData) *
+                                     COLORS_IN_PALETTE_FILE;
+
+// 16 + 16 remains for the default palette data.
+constexpr size_t COLORS_READ_FROM_PALETTE_FILE = 256 - 32;
+
+
+// -----------------------------------------------------------------------------
+// cgl::PaletteLoader
+// -----------------------------------------------------------------------------
+class PaletteReaderImpl : public cgl::IPaletteReader {
+ public:
+    explicit PaletteReaderImpl(const CreateInfo& createInfo);
+
+    ~PaletteReaderImpl();
+
+    // Try to open specific palet_*.cgp data but not read data yet.
+    cgl::Results read(cgl::EnvironmentPaletteTypes envPalette,
+                      cgl::PaletteData256*         pPaletteData) override;
+
+ private:
+    void appendDefaultpPaletteData(cgl::PaletteData256* pPaletteData) noexcept;
+
+    cgl::Results readPaletteFile(const std::filesystem::path& fullPath,
+                                 cgl::PaletteData256* pPaletteData);
+};
+
+PaletteReaderImpl::PaletteReaderImpl(const CreateInfo& createInfo)
+    : cgl::IPaletteReader(createInfo) {
+}
+
+PaletteReaderImpl::~PaletteReaderImpl() {
+}
+
+void PaletteReaderImpl::appendDefaultpPaletteData(
+    cgl::PaletteData256* pPaletteData
+) noexcept {
+    // setup default palette data
+    (*pPaletteData)[0].BGR   = {0x00, 0x00, 0x00};
+    (*pPaletteData)[1].BGR   = {0x00, 0x00, 0x80};
+    (*pPaletteData)[2].BGR   = {0x00, 0x80, 0x00};
+    (*pPaletteData)[3].BGR   = {0x00, 0x80, 0x80};
+    (*pPaletteData)[4].BGR   = {0x80, 0x00, 0x00};
+    (*pPaletteData)[5].BGR   = {0x80, 0x00, 0x80};
+    (*pPaletteData)[6].BGR   = {0x80, 0x80, 0x00};
+    (*pPaletteData)[7].BGR   = {0xC0, 0xC0, 0xC0};
+
+    (*pPaletteData)[8].BGR   = {0xC0, 0xDC, 0xC0};
+    (*pPaletteData)[9].BGR   = {0xF0, 0xCA, 0xA6};
+    (*pPaletteData)[10].BGR  = {0x00, 0x00, 0xDE};
+    (*pPaletteData)[11].BGR  = {0x00, 0x5F, 0xFF};
+    (*pPaletteData)[12].BGR  = {0xA0, 0xFF, 0xFF};
+    (*pPaletteData)[13].BGR  = {0xD2, 0x5F, 0x00};
+    (*pPaletteData)[14].BGR  = {0xFF, 0xD2, 0x50};
+    (*pPaletteData)[15].BGR  = {0x28, 0xE1, 0x28};
+
+    (*pPaletteData)[240].BGR = {0x96, 0xC3, 0xF5};
+    (*pPaletteData)[241].BGR = {0x5F, 0xA0, 0x1E};
+    (*pPaletteData)[242].BGR = {0x46, 0x7D, 0xC3};
+    (*pPaletteData)[243].BGR = {0x1E, 0x55, 0x9B};
+    (*pPaletteData)[244].BGR = {0x37, 0x41, 0x46};
+    (*pPaletteData)[245].BGR = {0x1E, 0x23, 0x28};
+    (*pPaletteData)[246].BGR = {0xF0, 0xFB, 0xFF};
+    (*pPaletteData)[247].BGR = {0xA5, 0x6E, 0x3A};
+
+    (*pPaletteData)[248].BGR = {0x80, 0x80, 0x80};
+    (*pPaletteData)[249].BGR = {0x00, 0x00, 0xFF};
+    (*pPaletteData)[250].BGR = {0x00, 0xFF, 0x00};
+    (*pPaletteData)[251].BGR = {0x00, 0xFF, 0xFF};
+    (*pPaletteData)[252].BGR = {0xFF, 0x00, 0x00};
+    (*pPaletteData)[253].BGR = {0xFF, 0x80, 0xFF};
+    (*pPaletteData)[254].BGR = {0xFF, 0xFF, 0x00};
+    (*pPaletteData)[255].BGR = {0xFF, 0xFF, 0xFF};
+}
+
+cgl::Results PaletteReaderImpl::readPaletteFile(
+    const std::filesystem::path& fullPath,
+    cgl::PaletteData256* pPaletteData
+) {
+    cgl::FileOpenInfo fileOpenInfo = cgl::TryOpenBinaryFile(fullPath);
+    if (fileOpenInfo.result != cgl::Results::Success) {
+        LOGE("Failed to open environment palette file {}, msg {}",
+             fullPath.string(), fileOpenInfo.errorMsg);
+        return fileOpenInfo.result;
+    }
+
+    // verify the size
+    size_t bufferSize = GetFileSize(&fileOpenInfo);
+    if (bufferSize != PALETTE_FILE_SIZE) {
+        LOGE("Invalid palette file size for '{}'. Expected {}, got {}",
+             fullPath.string(), PALETTE_FILE_SIZE, bufferSize);
+        return cgl::Results::Fail;
+    }
+
+    // read all PaletteLoader data
+    auto& stream = fileOpenInfo.stream.value();
+    stream.read(reinterpret_cast<char*>(pPaletteData->data() +
+                                        DEFAULT_PALETTE_OFFSET),
+                bufferSize);
+
+    return cgl::Results::Success;
+}
+
+cgl::Results PaletteReaderImpl::read(
+    cgl::EnvironmentPaletteTypes envPalette,
+    cgl::PaletteData256*         pPaletteData
+) {
+    // Get file info.
+    const auto cfg = createInfo().pSettings;
+    const auto resPath = cfg->envPalettePath(envPalette);
+    if (resPath.paletteType != envPalette) {
+        LOGE("Palette path mismatch for {}", cgl::GetString(envPalette));
+        return cgl::Results::Fail;
+    }
+
+    auto fullPath = std::filesystem::path(cfg->crossGateResourceRootDir) /
+                    std::filesystem::path(resPath.paletteFilePath);
+
+    LOGD("Loading env palette({}) from file : {}",
+         cgl::GetString(envPalette), fullPath.string());
+
+
+    // Load palette data
+    cgl::Results result = readPaletteFile(fullPath, pPaletteData);
+    if (result != cgl::Results::Success) {
+        return result;
+    }
+
+    // append default data into palette
+    appendDefaultpPaletteData(pPaletteData);
+
+    return cgl::Results::Success;
+}
+
+// -----------------------------------------------------------------------------
+// cgl::IPaletteReader
+// -----------------------------------------------------------------------------
+cgl::IPaletteReader::Ptr cgl::IPaletteReader::create(
+    const cgl::IPaletteReader::CreateInfo& createInfo
+) {
+    if (createInfo.pSettings == nullptr) {
+        return nullptr;
+    }
+
+    return std::make_unique<PaletteReaderImpl>(createInfo);
+}

--- a/src/settings/settings_loader.cpp
+++ b/src/settings/settings_loader.cpp
@@ -10,6 +10,7 @@
 #include <filesystem>
 #include "cgl/settings/settings.h"
 #include "cgl/settings/settings_loader.h"
+#include "cgl/resources/resource_types.h"
 
 using cgl::SettingsLoader;
 
@@ -83,6 +84,31 @@ const cgl::CrossGateResourcePaths& cgl::Settings::crossGateResourcePath(
     };
 
     return g_crossGateResourcePaths[static_cast<size_t>(version)];
+}
+
+const cgl::EnvironmentPaletteResourcePath& cgl::Settings::envPalettePath(
+    cgl::EnvironmentPaletteTypes paletteType
+) const noexcept {
+    static constexpr cgl::EnvironmentPaletteResourcePath g_pPaths[] = {
+        { cgl::EnvironmentPaletteTypes::Daytime,      "bin/pal/palet_00.cgp" },
+        { cgl::EnvironmentPaletteTypes::Evening,      "bin/pal/palet_01.cgp" },
+        { cgl::EnvironmentPaletteTypes::Night,        "bin/pal/palet_02.cgp" },
+        { cgl::EnvironmentPaletteTypes::EarlyMorning, "bin/pal/palet_03.cgp" },
+
+        // TODO(Miles) : decode the usage of other palette files in bin/pal/*
+
+        // invalid path
+        { cgl::EnvironmentPaletteTypes::Unknown,      "invalid-path" },
+    };
+
+    constexpr size_t pathCount = std::size(g_pPaths);
+    size_t index = static_cast<size_t>(paletteType);
+
+    if (index >= pathCount - 1) [[unlikely]] {
+        index = pathCount - 1;
+    }
+
+    return g_pPaths[index];
 }
 
 // -----------------------------------------------------------------------------

--- a/src/utils/enum_string_helper.cpp
+++ b/src/utils/enum_string_helper.cpp
@@ -49,3 +49,14 @@ const char* cgl::GetString(const cgl::GraphicsResourceIndexTypes& type) {
         return "Unknown";
     }
 }
+
+// -----------------------------------------------------------------------------
+const char* cgl::GetString(const cgl::EnvironmentPaletteTypes& type) {
+    switch (type) {
+#define CGL_X(name) case cgl::EnvironmentPaletteTypes::name: return #name;
+        EnvironmentPaletteTypes_ENUM_LIST
+#undef CGL_X
+    default:
+        return "Unknown";
+    }
+}

--- a/tests/resources/test_palette_reader.cpp
+++ b/tests/resources/test_palette_reader.cpp
@@ -1,0 +1,82 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2024-2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "cgl/settings/settings_loader.h"
+#include "cgl/settings/settings.h"
+#include "cgl/resources/palette_reader.h"
+
+// -----------------------------------------------------------------------------
+namespace {
+
+class IPaletteReaderTest : public testing::Test {
+ protected:
+    void SetUp() override {
+        cgl::SettingsLoader loader;
+        EXPECT_EQ(loader.settings(), nullptr);
+
+        settingLoader.load();
+        pSettings_ = settingLoader.settings();
+    }
+
+    const cgl::Settings* pSettings_;
+    cgl::SettingsLoader settingLoader;
+};
+
+}   // namespace
+
+// -----------------------------------------------------------------------------
+TEST_F(IPaletteReaderTest, ReaderCreation) {
+    // invalid creation
+    EXPECT_EQ(cgl::IPaletteReader::create({.pSettings = nullptr}), nullptr);
+
+    // valid creation
+    EXPECT_NE(cgl::IPaletteReader::create({.pSettings = pSettings_}), nullptr);
+}
+
+
+TEST_F(IPaletteReaderTest, ReadData) {
+    auto reader = cgl::IPaletteReader::create({.pSettings = pSettings_});
+    cgl::PaletteData256 paletteData;
+
+    EXPECT_EQ(reader->read(cgl::EnvironmentPaletteTypes::Daytime, &paletteData),
+              cgl::Results::Success);
+    EXPECT_EQ(paletteData.size() , 256);    // Test for 8bit color (256)
+}
+
+TEST_F(IPaletteReaderTest, CheckGlobalPaletteDefaultPaletteData) {
+    // Load data to check if the loading work find
+    auto reader = cgl::IPaletteReader::create({.pSettings = pSettings_});
+    cgl::PaletteData256 paleteA;
+    cgl::PaletteData256 paleteB;
+
+    EXPECT_EQ(reader->read(cgl::EnvironmentPaletteTypes::Daytime, &paleteA),
+              cgl::Results::Success);
+    EXPECT_EQ(reader->read(cgl::EnvironmentPaletteTypes::Evening, &paleteB),
+              cgl::Results::Success);
+
+    // The following two parts of the array are fixed values in the global
+    // palettes.
+    for (int32_t i = 0 ; i <= 15; i++) {
+        EXPECT_EQ(paleteA[i].BGR.R, paleteB[i].BGR.R);
+        EXPECT_EQ(paleteA[i].BGR.G, paleteB[i].BGR.G);
+        EXPECT_EQ(paleteA[i].BGR.B, paleteB[i].BGR.B);
+    }
+    for (int32_t i = 240 ; i <= 255; i++) {
+        EXPECT_EQ(paleteA[i].BGR.R, paleteB[i].BGR.R);
+        EXPECT_EQ(paleteA[i].BGR.G, paleteB[i].BGR.G);
+        EXPECT_EQ(paleteA[i].BGR.B, paleteB[i].BGR.B);
+    }
+}
+
+// -----------------------------------------------------------------------------
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Add IPaletteReader interface for loading environment palette data (bin/pal/*.cgp)

Reference : https://cgsword.com/filesystem_graphicmap.htm

- Defines an abstract interface for reading environment palette files
- Uses CreateInfo to pass configuration (currently Settings pointer)
- Provides virtual method `read()` to load palette data into PaletteData256
- Designed for polymorphic implementations (e.g., PaletteReaderImpl)
- Ownership handled via unique_ptr to enforce RAII

**Note**

Only a few palettes are resolved as `cgl::EnvironmentPaletteResourcePath` (Daytime, Evening, Night, and EarlyMorning) in this commit. We might need additional work or hacks to determine the usage of other palette .cgp files.