### PR TITLE
Add `IAnimeResourceDataReader` and `IAnimeResourceInfoReader` to read the anime info & data.

### DIFF
--- a/include/cgl/character/direction_types.h
+++ b/include/cgl/character/direction_types.h
@@ -1,0 +1,40 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2024-2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+#pragma once
+
+#include <cstdint>
+
+namespace cgl {
+
+// Define the core list of actual directions
+#define CGL_DIRECTION_TYPES_VALID_LIST  \
+    CGL_X(DIRECTION_NORTH)              \
+    CGL_X(DIRECTION_NORTH_EAST)         \
+    CGL_X(DIRECTION_EAST)               \
+    CGL_X(DIRECTION_SOUTH_EAST)         \
+    CGL_X(DIRECTION_SOUTH)              \
+    CGL_X(DIRECTION_SOUTH_WEST)         \
+    CGL_X(DIRECTION_WEST)               \
+    CGL_X(DIRECTION_NORTH_WEST)
+
+
+// Define the full list for the enum, including COUNT and special values
+#define CGL_DIRECTION_TYPES_ENUM_FULL_LIST  \
+    CGL_DIRECTION_TYPES_VALID_LIST          \
+    CGL_X(COUNT)                            \
+    CGL_X(UNKNOWN)
+
+
+enum class DirectionTypes : uint8_t {
+#define CGL_X(name) name,
+    CGL_DIRECTION_TYPES_ENUM_FULL_LIST
+#undef CGL_X
+};
+
+}   // namespace cgl

--- a/include/cgl/character/motion_types.h
+++ b/include/cgl/character/motion_types.h
@@ -1,0 +1,53 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2024-2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+#pragma once
+
+#include <cstdint>
+
+namespace cgl {
+
+// Define the core list of actual directions
+#define CGL_MOTION_TYPES_VALID_LIST  \
+    CGL_X(STANDARD)    \
+    CGL_X(WALK)        \
+    CGL_X(PRE_ATTACH)  \
+    CGL_X(RUN)         \
+    CGL_X(RESERVED_1)  \
+    CGL_X(ATTACK)      \
+    CGL_X(CAST_SPELL)  \
+    CGL_X(THROWING)    \
+    CGL_X(INJURED)     \
+    CGL_X(DEFENSE)     \
+    CGL_X(DEAD)        \
+    CGL_X(SIT)         \
+    CGL_X(HELLO)       \
+    CGL_X(HAPPY)       \
+    CGL_X(ANGRY)       \
+    CGL_X(SAD)         \
+    CGL_X(NOD)         \
+    CGL_X(ROCK)        \
+    CGL_X(SCISSORS)    \
+    CGL_X(PAPER)       \
+    CGL_X(FISHING)
+
+
+// Define the full list for the enum, including COUNT and special values
+#define CGL_MOTION_TYPES_ENUM_FULL_LIST  \
+    CGL_MOTION_TYPES_VALID_LIST          \
+    CGL_X(COUNT)                         \
+    CGL_X(UNKNOWN)
+
+
+enum class MotionTypes : uint8_t {
+#define CGL_X(name) name,
+    CGL_MOTION_TYPES_ENUM_FULL_LIST
+#undef CGL_X
+};
+
+}   // namespace cgl

--- a/include/cgl/resources/anime_resource.h
+++ b/include/cgl/resources/anime_resource.h
@@ -1,0 +1,67 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2024-2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+#pragma once
+
+#include <unordered_map>
+#include <vector>
+#include <utility>
+#include <functional>
+#include "cgl/core/version.h"
+#include "cgl/character/direction_types.h"
+#include "cgl/character/motion_types.h"
+
+namespace cgl {
+
+// -----------------------------------------------------------------------------
+// Anime Index/Data related section
+// -----------------------------------------------------------------------------
+struct AnimeResourceSerialNum {
+    cgl::CrossGateVersion version;
+    uint32_t value;
+};
+
+
+struct AnimeResourceInfo {
+    AnimeResourceSerialNum serialNum;
+    uint32_t dataOffset;
+    uint16_t motionCount;
+};
+
+
+using AnimeDataMapKey = std::pair<cgl::DirectionTypes, cgl::MotionTypes>;
+
+struct AnimeDataMapKeyHash {
+    template <class T1, class T2>
+    std::size_t operator () (const std::pair<T1, T2>& p) const {
+        auto h1 = std::hash<T1>{}(p.first);
+        auto h2 = std::hash<T2>{}(p.second);
+        return h1 ^ (h2 << 1);      // combine hashes
+    }
+};
+
+
+struct AnimeMotionDesc {
+    cgl::CrossGateVersion version;
+    cgl::DirectionTypes direction;
+    cgl::MotionTypes motion;
+    uint32_t duration;
+    std::vector<uint32_t> motionGraphicsSerialNums;
+};
+
+
+struct AnimeResourceData {
+    AnimeResourceSerialNum serialNum;
+
+    std::unordered_map<
+        cgl::AnimeDataMapKey,
+        cgl::AnimeMotionDesc,
+        cgl::AnimeDataMapKeyHash> motionMap;
+};
+
+}   // namespace cgl

--- a/include/cgl/resources/anime_resource_data_reader.h
+++ b/include/cgl/resources/anime_resource_data_reader.h
@@ -1,0 +1,53 @@
+// -----------------------------------------------------------------------------
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2024 MengLun,Cai
+//
+//   All rights reserved.
+//------------------------------------------------------------------------------
+
+#pragma once
+
+#include <memory>
+#include "cgl/core/version.h"
+#include "cgl/core/results.h"
+#include "cgl/resources/anime_resource.h"
+
+namespace cgl {
+
+struct Settings;
+
+class IAnimeResourceDataReader {
+ public:
+    using Ptr = std::unique_ptr<cgl::IAnimeResourceDataReader>;
+
+    struct CreateInfo {
+        const cgl::Settings*  pSettings;
+        cgl::CrossGateVersion version;
+    };
+
+    static cgl::IAnimeResourceDataReader::Ptr create(
+        const CreateInfo& createInfo);
+
+    explicit IAnimeResourceDataReader(const CreateInfo& createInfo)
+        : createInfo_(createInfo) {}
+
+    virtual ~IAnimeResourceDataReader() = default;
+
+    const CreateInfo& createInfo() const noexcept {
+        return createInfo_;
+    }
+
+    // Try to load specific Graphic*_*.bin data but not read data yet.
+    virtual cgl::Results load() = 0;
+
+    virtual cgl::Results query(
+        const cgl::AnimeResourceInfo& animeResInfo,
+        cgl::AnimeResourceData*       pAnimeResData) = 0;
+
+ private:
+    const CreateInfo createInfo_;
+};
+
+
+}   // namespace cgm

--- a/include/cgl/resources/anime_resource_info_reader.h
+++ b/include/cgl/resources/anime_resource_info_reader.h
@@ -1,0 +1,57 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2024-2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+
+#pragma once
+
+#include <memory>
+#include <vector>
+#include "cgl/core/version.h"
+#include "cgl/core/results.h"
+#include "cgl/resources/anime_resource.h"
+
+namespace cgl {
+
+struct Settings;
+
+// Open the specific AnimeInfo*_*.bin to read the data.
+class IAnimeResourceInfoReader {
+ public:
+    using Ptr = std::unique_ptr<IAnimeResourceInfoReader>;
+
+    struct CreateInfo {
+        const cgl::Settings*  pSettings;
+        cgl::CrossGateVersion version;
+    };
+
+    static cgl::IAnimeResourceInfoReader::Ptr create(
+        const CreateInfo& createInfo);
+
+    explicit IAnimeResourceInfoReader(const CreateInfo& createInfo)
+        : createInfo_(createInfo) {}
+
+    virtual ~IAnimeResourceInfoReader() = default;
+
+    const CreateInfo& createInfo() const noexcept {
+        return createInfo_;
+    }
+
+    virtual cgl::Results load() = 0;
+
+    virtual cgl::Results query(
+        const cgl::AnimeResourceSerialNum& index,
+        cgl::AnimeResourceInfo*            pInfo) = 0;
+
+    virtual cgl::Results queryAvailableSerialNums(
+        std::vector<cgl::AnimeResourceSerialNum>* pList) noexcept = 0;
+
+ private:
+    const CreateInfo createInfo_;
+};
+
+}   // namespace cgm

--- a/src/resources/anime_resource_data_reader.cpp
+++ b/src/resources/anime_resource_data_reader.cpp
@@ -1,0 +1,250 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2024-2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+
+#include <fstream>
+#include <filesystem>
+#include <memory>
+#include <sstream>
+#include <iostream>
+#include "cgl/settings/settings.h"
+#include "cgl/resources/anime_resource_data_reader.h"
+#include "cgl/utils/enum_string_helper.h"
+#include "utils/file_utils.h"
+#include "utils/logger.h"
+#include "utils/common.h"
+
+// -----------------------------------------------------------------------------
+// anonymous namespace
+// -----------------------------------------------------------------------------
+namespace {
+
+#pragma pack(1)
+struct AnimeDataRawMotionHeader {
+    uint16_t direction;
+    uint16_t motion;
+    uint32_t duraction;
+    uint32_t frameCount;
+};
+#pragma pack()
+
+
+#pragma pack(1)
+struct AnimeDataRawMotionFrame {
+    uint32_t serialNum;
+    uint8_t unknown[6];
+};
+#pragma pack()
+
+
+class ReaderImpl : public cgl::IAnimeResourceDataReader,
+                          cgl::FileBlockCache {
+ public:
+    explicit ReaderImpl(
+        const cgl::IAnimeResourceDataReader::CreateInfo& createInfo);
+
+    ~ReaderImpl();
+
+    cgl::Results load() override;
+
+    cgl::Results query(
+        const cgl::AnimeResourceInfo& animeResInfo,
+        cgl::AnimeResourceData*       pAnimeResData) override;
+
+    void destroy();
+
+ private:
+    cgl::CrossGateVersion version_;
+
+    std::vector<uint8_t> tempBlock_;
+};
+
+}   // namespace
+
+ReaderImpl::ReaderImpl(
+    const cgl::IAnimeResourceDataReader::CreateInfo& createInfo)
+    : cgl::IAnimeResourceDataReader(createInfo),
+      cgl::FileBlockCache(4096, 1024) {
+}
+
+ReaderImpl::~ReaderImpl() {
+    destroy();
+}
+
+void ReaderImpl::destroy() {
+}
+
+cgl::Results ReaderImpl::load() {
+    // prevent load multiple times.
+    if (isStreamReady()) {
+        LOGW("The anime resource data reader has already opened a file");
+        return cgl::Results::Success;
+    }
+
+    // Get file resource path configurations.
+    auto pSettings = createInfo().pSettings;
+    auto resPath   = pSettings->crossGateResourcePath(createInfo().version);
+    if ((resPath.version == cgl::CrossGateVersion::CG_VERSION_UNKNOWN) ||
+        (resPath.version != createInfo().version)) {
+        LOGE("Fail to query resource path configurations of version {}",
+             cgl::GetString(createInfo().version));
+        return cgl::Results::InvalidFile;
+    }
+
+    // open the file
+    std::filesystem::path fullPath =
+        std::filesystem::path(pSettings->crossGateResourceRootDir) /
+        std::filesystem::path(resPath.animeDataSubPath);
+    LOGD("Load graphics data from file `{}`", fullPath.string());
+
+    auto result = this->open(fullPath);
+    if (result != cgl::Results::Success) {
+        LOGE("Failed to open graphic date file {}", fullPath.string());
+        return result;
+    }
+
+    return cgl::Results::Success;
+}
+
+cgl::Results ReaderImpl::query(
+    const cgl::AnimeResourceInfo& animeResInfo,
+    cgl::AnimeResourceData*       pAnimeResData
+) {
+    // Check args
+    if (pAnimeResData == nullptr) {
+        LOGE("AnimeResourceData pointer is null");
+        return cgl::Results::InvalidArgs;
+    }
+
+    // keep for debug purpose
+    // LOGD("Query anime data for serial num {}:{}, offset {}",
+    //      cgl::GetString(animeResInfo.serialNum.version),
+    //      animeResInfo.serialNum.value,
+    //      animeResInfo.dataOffset);
+
+    if (animeResInfo.serialNum.version != createInfo().version) {
+        LOGE("Attempted to read anime data from a mismatched version: the "
+             "reader was created for `{}`, but the query requested data from "
+             "`{}`",
+             cgl::GetString(createInfo().version),
+             cgl::GetString(animeResInfo.serialNum.version));
+        return cgl::Results::InvalidArgs;
+    }
+
+    // Verify the index range, Every motion is require at least
+    // 1 AnimeDataRawMotionHeader + 1 AnimeRawFrameData for the data reading.
+    size_t offset = animeResInfo.dataOffset;
+    size_t readBound = offset +
+                       sizeof(cgl::AnimeResourceInfo) +
+                       sizeof(cgl::AnimeMotionDesc) * animeResInfo.motionCount;
+    if (readBound > this->fileSize()) {
+        LOGE("AnimeIndex {}'s address {} is out of range {}.",
+            animeResInfo.serialNum.value, animeResInfo.dataOffset, fileSize());
+        return cgl::Results::InvalidArgs;
+    }
+
+    // read all motions
+    pAnimeResData->serialNum = animeResInfo.serialNum;
+    pAnimeResData->motionMap.clear();
+    pAnimeResData->motionMap.reserve(animeResInfo.motionCount);
+    cgl::AnimeMotionDesc motionDesc;
+
+    for (uint16_t mIdx = 0; mIdx < animeResInfo.motionCount; mIdx++) {
+        // read motion header
+        AnimeDataRawMotionHeader header;
+        if (read(offset, sizeof(header), &header) != cgl::Results::Success) {
+            LOGE("Failed to read motion header for AnimeIndex {} at offset {}",
+                 animeResInfo.serialNum.value, offset);
+            return cgl::Results::Fail;
+        }
+        offset += sizeof(header);   // offset to read motion data
+
+        // verify the motion header
+        if (header.direction >= static_cast<int>(cgl::DirectionTypes::COUNT)) {
+            LOGE("AnimeIndex {}'s direction {} is out of range.",
+                 animeResInfo.serialNum.value, header.direction);
+            continue;
+        }
+        if (header.motion >= static_cast<int>(cgl::MotionTypes::COUNT)) {
+            LOGE("AnimeIndex {}'s motion {} is out of range.",
+                 animeResInfo.serialNum.value, header.motion);
+            continue;
+        }
+
+        // Read all motions data to temp buffer, assume the 1024 buffer is large
+        // enough to hold all motion frames.
+        static AnimeDataRawMotionFrame tempBuffer[1024];
+        assert(header.frameCount <= 1024);
+        size_t readCount = sizeof(AnimeDataRawMotionFrame) * header.frameCount;
+
+        if (read(offset, readCount, tempBuffer) != cgl::Results::Success) {
+            LOGE("Failed to read motion data for AnimeIndex {} at offset {}",
+                 animeResInfo.serialNum.value, offset);
+            return cgl::Results::Fail;
+        }
+        offset += readCount;   // offset to read next motion header
+
+
+        // keep for debug purpose, dump the motion frames
+        std::stringstream ss;
+        for (uint32_t i = 0; i < header.frameCount; i++) {
+            ss << tempBuffer[i].serialNum << " ";
+        }
+        LOGD("motion index [{}], header.direction {}, motion {} duraction {} "
+             "frameCount {} , frames : {}",
+            mIdx,
+            header.direction,
+            header.motion,
+            header.duraction,
+            header.frameCount,
+            ss.str());
+
+
+        // Update description
+        auto pRawFrames = tempBuffer;
+        cgl::AnimeMotionDesc desc {
+            .direction = static_cast<cgl::DirectionTypes>(header.direction),
+            .motion    = static_cast<cgl::MotionTypes>(header.motion),
+            .duration  = header.duraction
+        };
+        desc.motionGraphicsSerialNums.reserve(header.frameCount);
+
+        for (uint32_t i = 0; i < header.frameCount; i++) {
+            desc.motionGraphicsSerialNums.emplace_back(pRawFrames[i].serialNum);
+        }
+
+        auto key = std::make_pair(desc.direction, desc.motion);
+        pAnimeResData->motionMap.emplace(std::move(key), std::move(desc));
+    }
+
+    // Store the anime data
+    // *pAnimeResData = std::move(animeData);
+    // LOGI("AnimeResourceData for serialNum {} has {} motions",
+    //      cgl::GetString(pAnimeResData->serialNum),
+    //      pAnimeResData->motionMap.size());
+    // LOGI("AnimeResourceData for serialNum {} has {} motions",
+    //      cgl::GetString(pAnimeResData->serialNum),
+    //      pAnimeResData->motionMap.size());
+    return cgl::Results::Success;
+}
+
+//------------------------------------------------------------------------------
+// cgl::IAnimeResourceDataReader
+//------------------------------------------------------------------------------
+cgl::IAnimeResourceDataReader::Ptr
+cgl::IAnimeResourceDataReader::create(
+    const cgl::IAnimeResourceDataReader::CreateInfo& createInfo
+) {
+    // check args
+    if ((createInfo.pSettings == nullptr) ||
+        (createInfo.version >= cgl::CrossGateVersion::Count)) {
+        return nullptr;
+    }
+
+    return std::make_unique<ReaderImpl>(createInfo);
+}

--- a/src/resources/anime_resource_info_reader.cpp
+++ b/src/resources/anime_resource_info_reader.cpp
@@ -1,0 +1,245 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2024-2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+#include <fstream>
+#include <filesystem>
+#include <memory>
+#include "cgl/settings/settings.h"
+#include "cgl/resources/anime_resource_info_reader.h"
+#include "cgl/utils/enum_string_helper.h"
+#include "utils/file_utils.h"
+#include "utils/logger.h"
+
+using cgl::IAnimeResourceInfoReader;
+
+// -----------------------------------------------------------------------------
+// anonymous namespace
+// -----------------------------------------------------------------------------
+namespace {
+
+#pragma pack(push, 1)
+struct AnimeInfoRawData {
+    uint32_t index;
+    uint32_t address;
+    uint16_t motionCount;
+    uint16_t unknown;
+};
+#pragma pack(pop)
+
+
+class ReaderImpl : public cgl::IAnimeResourceInfoReader {
+ public:
+    explicit ReaderImpl(
+        const cgl::IAnimeResourceInfoReader::CreateInfo& createInf);
+
+    virtual ~ReaderImpl();
+
+    cgl::Results load() override;
+
+    cgl::Results query(
+        const cgl::AnimeResourceSerialNum& index,
+        cgl::AnimeResourceInfo*            pInfo) override;
+
+    cgl::Results queryAvailableSerialNums(
+        std::vector<cgl::AnimeResourceSerialNum>* pList) noexcept override;
+
+ private:
+    void destroy();
+
+    cgl::Results preLoad(size_t fileSize);
+
+    cgl::FileOpenInfo fileOpenInfo_;
+
+    std::unordered_map<uint32_t, cgl::AnimeResourceInfo> map_;
+};
+
+}   // namespace
+
+
+// -----------------------------------------------------------------------------
+// AnimeInfoRawData Impl
+// -----------------------------------------------------------------------------
+ReaderImpl::ReaderImpl(
+    const cgl::IAnimeResourceInfoReader::CreateInfo& createInfo)
+    : cgl::IAnimeResourceInfoReader(createInfo) {
+}
+
+// -----------------------------------------------------------------------------
+ReaderImpl::~ReaderImpl() {
+    destroy();
+}
+
+// -----------------------------------------------------------------------------
+void ReaderImpl::destroy() {
+    if ((fileOpenInfo_.stream.has_value()) &&
+        (fileOpenInfo_.stream->is_open())) {
+        fileOpenInfo_.stream->close();
+    }
+}
+
+// -----------------------------------------------------------------------------
+cgl::Results ReaderImpl::load() {
+    // Get file resource path configurations.
+    auto pSettings = createInfo().pSettings;
+    auto resPath   = pSettings->crossGateResourcePath(createInfo().version);
+    if ((resPath.version == cgl::CrossGateVersion::CG_VERSION_UNKNOWN) ||
+        (resPath.version != createInfo().version)) {
+        LOGE("Fail to query resource path configurations of version {}",
+             cgl::GetString(createInfo().version));
+        return cgl::Results::Fail;
+    }
+
+    // close previous data first.
+    if (cgl::IsFileOpen(fileOpenInfo_)) {
+        LOGW("The graphic index reader has already opened a file. Release the"
+             "previous one ...");
+        destroy();
+    }
+
+    // load file
+    std::filesystem::path fullPath =
+        std::filesystem::path(pSettings->crossGateResourceRootDir) /
+        std::filesystem::path(resPath.animeIndexSubPath);
+    LOGD("Load graphics index from file `{}`", fullPath.string());
+
+    fileOpenInfo_ = cgl::TryOpenBinaryFile(fullPath);
+    if (fileOpenInfo_.result != cgl::Results::Success) {
+        LOGE("Failed to open graphic index file {}, msg {}",
+             fullPath.string(), fileOpenInfo_.errorMsg);
+        return fileOpenInfo_.result;
+    }
+
+    // verify the size
+    size_t fileSize = GetFileSize(&fileOpenInfo_);
+    if (fileSize % sizeof(AnimeInfoRawData) != 0) {
+        LOGE("Failed to read the data from unmatch anime info file");
+        destroy();
+        return cgl::Results::InvalidFile;
+    }
+
+    // Anime info file is not sorted and just few kilobytes in size (usually
+    // less than 10KB) in most cases, so we can preload all entries to memory
+    // in this case. Maybe we can use a sorted file in the future or something
+    // like that, then we can use binary search to query the data.
+    // But for now, we just read all data to memory.
+    return preLoad(fileSize);
+}
+
+// -----------------------------------------------------------------------------
+cgl::Results ReaderImpl::preLoad(size_t fileSize) {
+    // allocate buffers
+    auto pBuffer = std::make_unique<uint8_t[]>(fileSize);
+    assert(pBuffer != nullptr);
+
+    // read all buffer data
+    auto& f = fileOpenInfo_.stream.value();
+    f.read(reinterpret_cast<char *>(pBuffer.get()), fileSize);
+
+    if (!f) {
+        // it should not happened since we have check the file size before
+        // preload(), but still check for safety.
+        LOGE("File read failed: only {} bytes read (expected {})",
+             f.gcount(), fileSize);
+        return cgl::Results::InvalidFile;
+    }
+
+    // parse all entries
+    const size_t count = fileSize / sizeof(AnimeInfoRawData);
+    auto pEntries = reinterpret_cast<AnimeInfoRawData *>(pBuffer.get());
+    map_.reserve(count);
+
+    for (size_t i = 0; i < count; i++) {
+        const auto& entry = pEntries[i];
+
+        // // debug purpose
+        // if (true) {
+        //     LOGI("- i[{}] index {}, address {}, motionCount {}",
+        //          i, entry.index, entry.address, entry.motionCount);
+        // }
+
+        // fill the map
+        cgl::AnimeResourceInfo info;
+        info.serialNum.version = createInfo().version;
+        info.serialNum.value   = entry.index;
+        info.dataOffset        = entry.address;
+        info.motionCount       = entry.motionCount;
+
+        map_[entry.index] = std::move(info);
+    }
+
+    return cgl::Results::Success;
+}
+
+// -----------------------------------------------------------------------------
+cgl::Results ReaderImpl::query(
+    const cgl::AnimeResourceSerialNum& serialNum,
+    cgl::AnimeResourceInfo*            pInfo
+)  {
+    if (pInfo == nullptr) {
+        LOGE("AnimeResourceInfo pointer is null");
+        return cgl::Results::InvalidArgs;
+    }
+
+    if (serialNum.version != createInfo().version) {
+        LOGE("Invalid version {} for query, expected {}",
+             cgl::GetString(serialNum.version),
+             cgl::GetString(createInfo().version));
+        return cgl::Results::InvalidArgs;
+    }
+
+    // find the entry
+    auto it = map_.find(serialNum.value);
+    if (it == map_.end()) {
+        if (map_.empty()) {
+            LOGE("Anime info map is empty, please load the reader first");
+        } else {
+            LOGE("Anime info with serial num {} not found", serialNum.value);
+        }
+        return cgl::Results::IndexNotExist;
+    }
+
+    // fill the output info
+    *pInfo = it->second;
+    assert(pInfo->serialNum.version == createInfo().version);
+
+    return cgl::Results::Success;
+}
+
+// -----------------------------------------------------------------------------
+cgl::Results ReaderImpl::queryAvailableSerialNums(
+    std::vector<cgl::AnimeResourceSerialNum>* pList
+) noexcept {
+    if (pList == nullptr) {
+        LOGE("AnimeResourceSerialNum list pointer is null");
+        return cgl::Results::InvalidArgs;
+    }
+
+    pList->reserve(map_.size());
+    for (const auto& [key, value] : map_) {
+        pList->emplace_back(value.serialNum);
+    }
+    LOGD("Query available anime serial nums, count: {}", pList->size());
+
+    return cgl::Results::Success;
+}
+
+// -----------------------------------------------------------------------------
+// cgm::IAnimeResourceInfoReader
+// -----------------------------------------------------------------------------
+IAnimeResourceInfoReader::Ptr cgl::IAnimeResourceInfoReader::create(
+    const CreateInfo& createInfo
+) {
+    // check args
+    if ((createInfo.pSettings == nullptr) ||
+        (createInfo.version >= cgl::CrossGateVersion::Count)) {
+        LOGE("Invalid create info for IAnimeResourceInfoReader");
+        return nullptr;
+    }
+
+    return std::make_unique<ReaderImpl>(createInfo);
+}

--- a/tests/resources/test_anime_resource_data_reader.cpp
+++ b/tests/resources/test_anime_resource_data_reader.cpp
@@ -1,0 +1,116 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2024-2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "cgl/settings/settings_loader.h"
+#include "cgl/settings/settings.h"
+#include "cgl/resources/anime_resource_info_reader.h"
+#include "cgl/resources/anime_resource_data_reader.h"
+
+// -----------------------------------------------------------------------------
+namespace {
+
+class IAnimeResourceDataReaderTest : public testing::Test {
+ protected:
+    void SetUp() override {
+        cgl::SettingsLoader loader;
+        EXPECT_EQ(loader.settings(), nullptr);
+
+        settingLoader.load();
+        pSettings_ = settingLoader.settings();
+
+        // prepare info reader
+        infoReader_ = cgl::IAnimeResourceInfoReader::create({
+            .pSettings = pSettings_,
+            .version   = cgl::CrossGateVersion::CG_VERSION_Classic
+        });
+        EXPECT_NE(infoReader_, nullptr);
+        EXPECT_EQ(infoReader_->load(), cgl::Results::Success);
+    }
+
+    const cgl::Settings* pSettings_;
+    cgl::SettingsLoader settingLoader;
+    cgl::IAnimeResourceInfoReader::Ptr infoReader_;
+};
+
+}   // namespace
+
+// -----------------------------------------------------------------------------
+TEST_F(IAnimeResourceDataReaderTest, ReaderInit) {
+    // invalid init args check
+    EXPECT_EQ(cgl::IAnimeResourceDataReader::create({
+                .pSettings = nullptr,
+                .version   = cgl::CrossGateVersion::CG_VERSION_UNKNOWN
+              }), nullptr);
+
+    EXPECT_EQ(cgl::IAnimeResourceDataReader::create({
+                .pSettings = pSettings_,
+                .version   = cgl::CrossGateVersion::CG_VERSION_UNKNOWN
+              }), nullptr);
+
+    EXPECT_EQ(cgl::IAnimeResourceDataReader::create({
+                .pSettings = pSettings_,
+                .version   = cgl::CrossGateVersion::Count
+              }), nullptr);
+
+    // valid creation
+    cgl::IAnimeResourceDataReader::CreateInfo cInfo {
+        .pSettings = pSettings_,
+        .version   = cgl::CrossGateVersion::CG_VERSION_PUK1
+    };
+    auto reader = cgl::IAnimeResourceDataReader::create(cInfo);
+    EXPECT_NE(reader, nullptr);
+    EXPECT_EQ(reader->createInfo().pSettings, cInfo.pSettings);
+    EXPECT_EQ(reader->createInfo().version, cInfo.version);
+}
+
+// -----------------------------------------------------------------------------
+TEST_F(IAnimeResourceDataReaderTest, LoadData) {
+    // prepare info
+    cgl::AnimeResourceInfo animeResInfo;
+    infoReader_->query(
+        cgl::AnimeResourceSerialNum{
+            .version = cgl::CrossGateVersion::CG_VERSION_Classic,
+            .value   = 100000
+        },
+        &animeResInfo);
+
+    // Create the data reader
+    auto reader = cgl::IAnimeResourceDataReader::create({
+      .pSettings = pSettings_,
+      .version   = cgl::CrossGateVersion::CG_VERSION_Classic
+    });
+    EXPECT_NE(reader, nullptr);
+
+    // Try to load the version data.
+    cgl::Results result = reader->load();
+    EXPECT_EQ(result, cgl::Results::Success);
+
+    // Try to query data
+    cgl::AnimeResourceData animeData;
+    result = reader->query(animeResInfo, &animeData);
+    EXPECT_EQ(result, cgl::Results::Success);
+
+    // Check the data
+    EXPECT_EQ(animeData.serialNum.version, animeResInfo.serialNum.version);
+    EXPECT_EQ(animeData.serialNum.value, animeResInfo.serialNum.value);
+    EXPECT_EQ(animeData.motionMap.size(), animeResInfo.motionCount);
+    for (const auto& [key, motionDesc] : animeData.motionMap) {
+        EXPECT_EQ(motionDesc.version, animeResInfo.serialNum.version);
+        EXPECT_EQ(motionDesc.direction, key.first);
+        EXPECT_EQ(motionDesc.motion, key.second);
+        EXPECT_GT(motionDesc.motionGraphicsSerialNums.size(), 0);
+    }
+}
+
+// -----------------------------------------------------------------------------
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/resources/test_anime_resource_info_reader.cpp
+++ b/tests/resources/test_anime_resource_info_reader.cpp
@@ -1,0 +1,100 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2024-2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "cgl/settings/settings_loader.h"
+#include "cgl/settings/settings.h"
+#include "cgl/resources/anime_resource_info_reader.h"
+
+// -----------------------------------------------------------------------------
+namespace {
+
+class IAnimeResourceInfoReaderTest : public testing::Test {
+ protected:
+    void SetUp() override {
+        cgl::SettingsLoader loader;
+        EXPECT_EQ(loader.settings(), nullptr);
+
+        settingLoader.load();
+        pSettings_ = settingLoader.settings();
+    }
+
+    const cgl::Settings* pSettings_;
+    cgl::SettingsLoader settingLoader;
+};
+
+}   // namespace
+
+// -----------------------------------------------------------------------------
+TEST_F(IAnimeResourceInfoReaderTest, ReaderInit) {
+    // invalid init args check
+    EXPECT_EQ(cgl::IAnimeResourceInfoReader::create({
+                .pSettings = nullptr,
+                .version   = cgl::CrossGateVersion::CG_VERSION_UNKNOWN
+              }), nullptr);
+
+    EXPECT_EQ(cgl::IAnimeResourceInfoReader::create({
+                .pSettings = pSettings_,
+                .version   = cgl::CrossGateVersion::CG_VERSION_UNKNOWN
+              }), nullptr);
+
+    EXPECT_EQ(cgl::IAnimeResourceInfoReader::create({
+                .pSettings = pSettings_,
+                .version   = cgl::CrossGateVersion::Count
+              }), nullptr);
+
+    // valid creation
+    cgl::IAnimeResourceInfoReader::CreateInfo cInfo {
+        .pSettings = pSettings_,
+        .version   = cgl::CrossGateVersion::CG_VERSION_PUK1
+    };
+    auto reader = cgl::IAnimeResourceInfoReader::create(cInfo);
+    EXPECT_NE(reader, nullptr);
+    EXPECT_EQ(reader->createInfo().pSettings, cInfo.pSettings);
+    EXPECT_EQ(reader->createInfo().version, cInfo.version);
+}
+
+// -----------------------------------------------------------------------------
+TEST_F(IAnimeResourceInfoReaderTest, LoadData) {
+    auto reader = cgl::IAnimeResourceInfoReader::create({
+      .pSettings = pSettings_,
+      .version   = cgl::CrossGateVersion::CG_VERSION_Classic
+    });
+    EXPECT_NE(reader, nullptr);
+
+    // Try to load the version data.
+    cgl::Results result = reader->load();
+    EXPECT_EQ(result, cgl::Results::Success);
+
+    // Check if the reader has loaded data.
+    std::vector<cgl::AnimeResourceSerialNum> serialNums;
+    result = reader->queryAvailableSerialNums(&serialNums);
+    EXPECT_EQ(result, cgl::Results::Success);
+
+    // Try to query data
+    cgl::AnimeResourceInfo info;
+    for (const auto& idx : serialNums) {
+        EXPECT_EQ(idx.version, cgl::CrossGateVersion::CG_VERSION_Classic);
+        EXPECT_GT(idx.value, 0);
+
+        // Query the info
+        result = reader->query(idx, &info);
+        EXPECT_EQ(result, cgl::Results::Success);
+        EXPECT_EQ(info.serialNum.version, idx.version);
+        EXPECT_EQ(info.serialNum.value, idx.value);
+        EXPECT_GE(info.dataOffset, 0);
+        EXPECT_GT(info.motionCount, 0);
+    }
+}
+
+// -----------------------------------------------------------------------------
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
The Cross Gate anime file format is referenced from :  https://cgsword.com/image/filesystem/map/fanicer.gif

- Add `IAnimeResourceDataReader` and `IAnimeResourceInfoReader` to read the anime info & data.
- Introduce AnimeData struct to store resource serial number and direction/motion mapping via motionMap.
- Add PairHash utility for unordered_map with std::pair<cgl::DirectionTypes, cgl::MotionTypes> as key.
- Implement initial data structures and interfaces to support anime-related resource handling in the engine.
