### PR TITLE
Add `bin\AnimeViewer` for previewing Anime data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 if (MSVC)
-    # add_compile_options(/EHsc)
+    add_compile_options(/EHsc)
 
     # Enable UTF-8 encoding for build with spdlog
     add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")

--- a/README.md
+++ b/README.md
@@ -21,21 +21,28 @@ This project is not a private server or an attempt to infringe upon the rights o
 
 ### 1. Clone the repository
 
-    git clone https://github.com/ML-Cai/CrossGate-Legacy.git
-    cd CrossGate-Legacy
+```bash
+git clone https://github.com/ML-Cai/CrossGate-Legacy.git
+cd CrossGate-Legacy
+```
 
 ### 2. Install requirements
 
-    conda create --name cgl python=3.10
-    conda activate cgl
-    python setup_requirements.py --build_type RelWithDebInfo
+```bash
+# Open `x64 Native Tools Command Prompt for VS2022` as command prompt in Windows build
+python -m venv .venv
+.venv\Scripts\activate
+python setup_requirements.py --build_typeRelWithDebInfo
+```
 
 ### 3. Building CGL
 
-    mkdir build
-    cd build
-    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
-    cmake --build . --config RelWithDebInfo
+```bash
+mkdir build
+cd build
+cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+cmake --build . --config RelWithDebInfo
+```
 
 ## Run
 

--- a/bin/AnimeViewer/anime_viewer.py
+++ b/bin/AnimeViewer/anime_viewer.py
@@ -1,0 +1,101 @@
+# ======================================================================================================================
+#   The MIT License (MIT)
+#
+#   Copyright (c) 2024-2025 MengLun,Cai
+#
+#   All rights reserved.
+# ======================================================================================================================
+import sys
+import os
+from PIL import Image
+
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../build/bin"))
+import cgl
+
+cross_gate_version_map = {e.name: e for e in cgl.CrossGateVersionList()}
+env_palette_type_map = {e.name: e for e in cgl.EnvironmentPaletteTypesList()}
+
+# ----------------------------------------------------------------------------------------------------------------------
+class App:
+    def __init__(self):
+        self.session = cgl.Session()
+
+    def launch(self):
+        palette = cgl.EnvironmentPaletteTypes.Daytime
+        palette = self.session.acquire_env_palette(palette)
+
+        version         = cgl.CG_VERSION_Classic.CG_VERSION_Classic
+        # anime_seral_num = 101000
+        anime_seral_num = 101406
+        anime_res_bundle = self.session.acquire_anime_resource(version, anime_seral_num)
+        if anime_res_bundle is None:
+            print("No anime data found for the given version and serial number.")
+            return
+
+        all_keys = anime_res_bundle.keys()
+        for key in all_keys:
+            dir, motion = key
+            # print(f"Key -> {key},  {type(key[0])},  {type(key[1])}")
+            anime_data = anime_res_bundle.acquire(dir, motion)
+            # print(type(anime_data))
+            # print(f"anime_data {anime_data.version}, {anime_data.direction}, {anime_data.motion}, {anime_data.duration}, {anime_data.motionGraphicsSerialNums}")
+
+
+            # generate gif source
+            gif_src = []
+            bbox = [0, 0, 0, 0]     # left, right, top, bottom
+            for serial_num in anime_data.motionGraphicsSerialNums:
+                gfx_data = self.session.acquire_graphics_resource(version, serial_num)
+
+                # generate image
+                img = self.session.apply_palette(gfx_data, palette)
+                img = img[:, :, [2, 1, 0]]  # Convert RGB to BGR
+                img = img[::-1, :, :]       # Flip vertically
+                img = Image.fromarray(img)
+
+                # determine max width and height in current animation images
+                width, height      = img.size
+                offset_x, offset_y = gfx_data.offset()
+                bbox[0] = min(bbox[0], offset_x)                     # left
+                bbox[1] = max(bbox[1], offset_x + width)
+                bbox[2] = min(bbox[2], offset_y)                     # top
+                bbox[3] = max(bbox[3], offset_y + height)
+
+                # append to gif source
+                gif_src.append((img, gfx_data.offset()))
+
+            aligned_images = []
+            gif_width  = bbox[1] - bbox[0]
+            gif_height = bbox[3] - bbox[2]
+            for img_bundle in gif_src:
+                img = Image.new('RGBA', (gif_width, gif_height), (0, 0, 0, 255))
+
+                src_offset_x, src_offset_y = img_bundle[1]
+
+                offset_x = int(src_offset_x + -bbox[0])
+                offset_y = int(src_offset_y + -bbox[2])
+
+                # align image to the same top-left corner
+                img.paste(img_bundle[0], (offset_x, offset_y))
+                aligned_images.append(img)
+
+            # create gif
+            if aligned_images:
+                gif_path = f"anime_{anime_data.direction.name}_{anime_data.motion.name}.gif"
+                aligned_images[0].save(
+                    gif_path,
+                    save_all=True,
+                    append_images=aligned_images[1:],
+                    loop=0,
+                    # duration=anime_data.duration/len(aligned_images),
+                    duration=anime_data.duration/len(aligned_images),
+                    optimize=False
+                )
+                print(f"Saved GIF: {gif_path}")
+
+            break
+
+# ------------------------------------------------------------------------------
+if __name__ == "__main__":
+    app = App()
+    app.launch()

--- a/bin/GraphicsDataViewer/graphics_data_viewer.py
+++ b/bin/GraphicsDataViewer/graphics_data_viewer.py
@@ -53,9 +53,9 @@ class GraphicsDataViewerApp:
         images = []
         for i in range(start_serial_num, end_serial_num):
             serial_num  = available_serial_nums[i]
-            gfx_data = self.session.acquire_graphics_data(version, serial_num)
-            if (gfx_data is not None) and (palette is not None):
-                img      = self.session.apply_palette(gfx_data, palette)
+            gfx_resource = self.session.acquire_graphics_resource(version, serial_num)
+            if (gfx_resource is not None) and (palette is not None):
+                img      = self.session.apply_palette(gfx_resource, palette)
                 img      = img[:, :, [2, 1, 0]]
                 img      = img[::-1, :, :]
                 images.append((img, f"S/N: {serial_num}"))

--- a/include/cgl/resources/resource_types.h
+++ b/include/cgl/resources/resource_types.h
@@ -74,7 +74,7 @@ struct GraphicsResourceSerialNum {
 
     cgl::GraphicsResourceSerialNumTypes type;
     cgl::CrossGateVersion version;
-    int32_t value;
+    uint32_t value;
 
     bool operator==(const cgl::GraphicsResourceSerialNum& other) const {
         return (type == other.type) &&

--- a/include/cgl/utils/enum_string_helper.h
+++ b/include/cgl/utils/enum_string_helper.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <string>
 
 namespace cgl {
 
@@ -17,9 +18,15 @@ enum class CrossGateVersion : uint8_t;
 enum class GraphicsResourceSerialNumTypes : uint8_t;
 enum class EnvironmentPaletteTypes : uint8_t;
 
+struct GraphicsResourceSerialNum;
+struct AnimeResourceSerialNum;
+
 const char* GetString(const cgl::Results& type);
 const char* GetString(const cgl::CrossGateVersion& type);
 const char* GetString(const cgl::GraphicsResourceSerialNumTypes& type);
 const char* GetString(const cgl::EnvironmentPaletteTypes& type);
+
+std::string toStr(const cgl::GraphicsResourceSerialNum&);
+std::string toStr(const cgl::AnimeResourceSerialNum&);
 
 }   // namespace cgl

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -35,7 +35,7 @@ set(PYTHON_LIB_PATH "${Python3_LIBRARY_RELEASE}")
 #-------------------------------------------------------------------------------
 add_library(${PROJECT_NAME} MODULE cgl_pybind.cpp)
 target_include_directories(${PROJECT_NAME}  PRIVATE ${Python3_INCLUDE_DIRS})
-target_link_libraries(${PROJECT_NAME} PRIVATE pybind11::pybind11 ${PYTHON_LIB_PATH} cgl)
+target_link_libraries(${PROJECT_NAME} PRIVATE pybind11::pybind11 ${PYTHON_LIB_PATH} cgl spdlog::spdlog)
 
 set(CGL_OUTPUT_DIR ${CMAKE_BINARY_DIR}/bin)
 set_target_properties(${PROJECT_NAME} PROPERTIES

--- a/python/cgl_pybind.cpp
+++ b/python/cgl_pybind.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <cstdint>
 #include <memory>
+#include <sstream>
 #include <unordered_map>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -20,20 +21,39 @@
 #include "cgl/resources/resource_types.h"
 #include "cgl/resources/graphics_resource_file_info_reader.h"
 #include "cgl/resources/graphics_resource_file_data_reader.h"
+#include "cgl/resources/anime_resource_info_reader.h"
+#include "cgl/resources/anime_resource_data_reader.h"
 #include "cgl/resources/palette_reader.h"
+#include "cgl/character/direction_types.h"
+#include "cgl/character/motion_types.h"
 #include "cgl/utils/enum_string_helper.h"
+#include "utils/logger.h"
+#include "holders.h"
 
 namespace py = pybind11;
 
-// -----------------------------------------------------------------------------
+
 namespace {
 
+// -----------------------------------------------------------------------------
 template<typename T>
 inline void remove(std::vector<T>* v, T target) {
     auto it = std::find(v->begin(), v->end(), target);
     if (it != v->end()) {
         v->erase(it);
     }
+}
+
+// -----------------------------------------------------------------------------
+template <typename T>
+std::string type_name() {
+#if defined(__clang__) || defined(__GNUC__)
+    return abi::__cxa_demangle(typeid(T).name(), nullptr, nullptr, nullptr);
+#elif defined(_MSC_VER)
+    return typeid(T).name();
+#else
+    return typeid(T).name();
+#endif
 }
 
 // -----------------------------------------------------------------------------
@@ -59,22 +79,7 @@ std::vector<cgl::CrossGateVersion> GetTypes_CrossGateVersion() {
     return result;
 }
 
-
 // -----------------------------------------------------------------------------
-inline void* acquire_ptr(py::object obj) {
-    if (obj.is_none()) return nullptr;
-
-    if (py::isinstance<py::capsule>(obj) == false) {
-        throw std::invalid_argument("Expected py::capsule for arguments");
-    }
-    return obj.cast<py::capsule>().get_pointer();
-}
-
-
-struct PaletteData256Holder {
-    cgl::PaletteData256 data;
-};
-
 class Session {
 public:
     Session();
@@ -82,11 +87,7 @@ public:
     size_t acquire_graphics_data_count(
         cgl::CrossGateVersion version);
 
-    std::shared_ptr<cgl::GraphicsResourceData> acquire_graphics_data(
-        cgl::CrossGateVersion version,
-        int32_t               idx);
-
-    std::shared_ptr<PaletteData256Holder> acquire_env_palette(
+    cgl::py::PaletteData256Holder::Ptr acquire_env_palette(
         cgl::EnvironmentPaletteTypes envPalette);
 
     std::vector<uint8_t> apply_palette(
@@ -95,6 +96,16 @@ public:
 
     std::vector<int32_t> acquire_available_serial_nums(
         cgl::CrossGateVersion version);
+
+    cgl::py::GraphicsResourceBundleHolder::Ptr
+    acquire_graphics_resource(
+        cgl::CrossGateVersion version,
+        uint32_t              serial_num);
+
+    cgl::py::AnimeResourceDataHolder::Ptr
+    acquire_anime_resource(
+        cgl::CrossGateVersion version,
+        uint32_t              anime_serial_num);
 
 private:
     int width_, height_;
@@ -113,62 +124,66 @@ private:
 
     cgl::IPaletteReader::Ptr paletteReader_;
 
-    cgl::IGraphicsResourceFileInfoReader* acquireInfoReader(
-        cgl::CrossGateVersion version);
+    std::unordered_map<
+        cgl::CrossGateVersion,
+        cgl::IAnimeResourceInfoReader::Ptr> animeInfoReaderMap_;
 
-    cgl::IGraphicsResourceFileDataReader* acquireDataReader(
-        cgl::CrossGateVersion version);
+    std::unordered_map<
+        cgl::CrossGateVersion,
+        cgl::IAnimeResourceDataReader::Ptr> animeDataReaderMap_;
 
     cgl::IPaletteReader* acquirePaletteReader(
         cgl::EnvironmentPaletteTypes envPalette);
+
+    template <typename ReaderInterface, typename MapType>
+    ReaderInterface* acquireReader(
+        MapType& readerMap,
+        const cgl::CrossGateVersion version);
 };
 
 }   // namespace
 
+
+// -----------------------------------------------------------------------------
 Session::Session() {
     cgl::SettingsLoader loader;
     settingLoader_.load();
     pSettings_ = settingLoader_.settings();
 }
 
-cgl::IGraphicsResourceFileInfoReader* Session::acquireInfoReader(
-    cgl::CrossGateVersion version
+// -----------------------------------------------------------------------------
+template <typename ReaderInterface, typename MapType>
+ReaderInterface* Session::acquireReader(
+    MapType& readerMap,
+    const cgl::CrossGateVersion version
 ) {
-    auto& reader = infoReaderMap_[version];
+    auto& reader = readerMap[version];
     if (!reader) {
-        reader = cgl::IGraphicsResourceFileInfoReader::create({
+        LOGD("Create `{}` for version `{}`", type_name<ReaderInterface>(),
+             cgl::GetString(version));
+
+        reader = ReaderInterface::create({
             .pSettings = pSettings_,
             .version   = version
         });
+
         if (!reader) {
-            throw std::invalid_argument("Failed to create the reader");
+            std::stringstream ss;
+            ss << "Failed to create " << type_name<ReaderInterface>()
+               << " for version " << cgl::GetString(version);
+            throw std::invalid_argument(ss.str());
         }
         if (reader->load() != cgl::Results::Success) {
-            throw std::invalid_argument("Failed to load the reader");
+            std::stringstream ss;
+            ss << "Failed to load " << type_name<ReaderInterface>()
+               << " for version " << cgl::GetString(version);
+            throw std::invalid_argument(ss.str());
         }
     }
     return reader.get();
 }
 
-cgl::IGraphicsResourceFileDataReader* Session::acquireDataReader(
-    cgl::CrossGateVersion version
-) {
-    auto& reader = dataReaderMap_[version];
-    if (!reader) {
-        reader = cgl::IGraphicsResourceFileDataReader::create({
-            .pSettings = pSettings_,
-            .version   = version
-        });
-        if (!reader) {
-            throw std::invalid_argument("Failed to create the reader");
-        }
-        if (reader->load() != cgl::Results::Success) {
-            throw std::invalid_argument("Failed to load the reader");
-        }
-    }
-    return reader.get();
-}
-
+// -----------------------------------------------------------------------------
 cgl::IPaletteReader* Session::acquirePaletteReader(
     cgl::EnvironmentPaletteTypes envPalette
 ) {
@@ -183,56 +198,35 @@ cgl::IPaletteReader* Session::acquirePaletteReader(
     return paletteReader_.get();
 }
 
+// -----------------------------------------------------------------------------
 size_t Session::acquire_graphics_data_count(
     cgl::CrossGateVersion version
 ) {
-    return acquireInfoReader(version)->infoCount();
+    auto reader = acquireReader<cgl::IGraphicsResourceFileInfoReader>(
+                    infoReaderMap_, version);
+    return reader->infoCount();
 }
 
-std::shared_ptr<cgl::GraphicsResourceData> Session::acquire_graphics_data(
-    cgl::CrossGateVersion version,
-    int32_t               idx
-) {
-    auto infoReader = acquireInfoReader(version);
-    auto dataReader = acquireDataReader(version);
-
-    cgl::GraphicsResourceSerialNum resIdx {
-        .type    = cgl::GraphicsResourceSerialNumTypes::GraphicsSerialNum,
-        .version = cgl::CrossGateVersion::CG_VERSION_Classic,
-        .value   = idx
-    };
-    cgl::GraphicsResourceInfo info;
-    if (infoReader->query(resIdx, &info) != cgl::Results::Success) {
-        printf("Failed to query info %s:%d\n", cgl::GetString(version), idx);
-        return nullptr;
-    }
-
-    auto data = std::make_shared<cgl::GraphicsResourceData>();
-    if (dataReader->query(info, data.get()) != cgl::Results::Success) {
-        printf("Failed to query data %s:%d\n", cgl::GetString(version), idx);
-        return nullptr;
-    }
-
-    return data;
-}
-
-std::shared_ptr<PaletteData256Holder> Session::acquire_env_palette(
+// -----------------------------------------------------------------------------
+cgl::py::PaletteData256Holder::Ptr Session::acquire_env_palette(
     cgl::EnvironmentPaletteTypes envPalette
 ) {
     auto infoReader = acquirePaletteReader(envPalette);
 
-    auto data = std::make_shared<PaletteData256Holder>();
+    auto data = std::make_shared<cgl::py::PaletteData256Holder>();
     if (infoReader->read(envPalette, &data->data) != cgl::Results::Success) {
-        printf("Failed to query palette %s\n", cgl::GetString(envPalette));
+        LOGE("Failed to query palette {}", cgl::GetString(envPalette));
         return nullptr;
     }
     return data;
 }
 
+// -----------------------------------------------------------------------------
 std::vector<int32_t> Session::acquire_available_serial_nums(
     cgl::CrossGateVersion version
 ) {
-    auto reader = acquireInfoReader(version);
+    auto reader = acquireReader<cgl::IGraphicsResourceFileInfoReader>(
+                    infoReaderMap_, version);
 
     std::vector<int32_t> ret;
     if (reader->queryAvailableSerialNums(&ret) != cgl::Results::Success) {
@@ -241,12 +235,14 @@ std::vector<int32_t> Session::acquire_available_serial_nums(
     return ret;
 }
 
+// -----------------------------------------------------------------------------
 std::vector<uint8_t> Session::apply_palette(
     void* pGfxDataHandle,
     void* pPletteHandle
 ) {
-    auto pGfxResData = static_cast<cgl::GraphicsResourceData *>(pGfxDataHandle);
-    auto pPaletteHolder = static_cast<PaletteData256Holder *>(pPletteHandle);
+    auto pHolder = static_cast<cgl::py::GraphicsResourceBundleHolder *>(pGfxDataHandle);
+    auto pPaletteHolder = static_cast<cgl::py::PaletteData256Holder *>(pPletteHandle);
+    auto pGfxResData = &pHolder->data;
 
     std::vector<uint8_t> img;
     size_t count = pGfxResData->width * pGfxResData->height;
@@ -276,6 +272,81 @@ std::vector<uint8_t> Session::apply_palette(
 }
 
 // -----------------------------------------------------------------------------
+cgl::py::AnimeResourceDataHolder::Ptr Session::acquire_anime_resource(
+    cgl::CrossGateVersion version,
+    uint32_t              serial_num
+) {
+    auto infoReader = acquireReader<cgl::IAnimeResourceInfoReader>(
+                        animeInfoReaderMap_, version);
+    auto dataReader = acquireReader<cgl::IAnimeResourceDataReader>(
+                        animeDataReaderMap_, version);
+
+    if (!infoReader || !dataReader) {
+        LOGE("Failed to acquire anime resource readers for version {}",
+               cgl::GetString(version));
+        return nullptr;
+    }
+
+    cgl::AnimeResourceInfo info;
+    cgl::AnimeResourceSerialNum sn {
+        .version = version,
+        .value   = serial_num
+    };
+
+    // query info first
+    if (infoReader->query(sn, &info) != cgl::Results::Success) {
+        LOGE("Failed to query anime info via S/N [{}]", cgl::toStr(sn));
+        return nullptr;
+    }
+
+    // query anime data to the holder
+    auto holder = std::make_shared<cgl::py::AnimeResourceDataHolder>();
+    if (dataReader->query(info, &holder->animeData) != cgl::Results::Success) {
+        LOGE("Failed to query anime data via S/N [{}]", cgl::toStr(sn));
+        return nullptr;
+    }
+
+    return holder;
+}
+
+// -----------------------------------------------------------------------------
+cgl::py::GraphicsResourceBundleHolder::Ptr Session::acquire_graphics_resource(
+    cgl::CrossGateVersion version,
+    uint32_t              serial_num
+) {
+    auto infoReader = acquireReader<cgl::IGraphicsResourceFileInfoReader>(
+                        infoReaderMap_, version);
+    auto dataReader = acquireReader<cgl::IGraphicsResourceFileDataReader>(
+                        dataReaderMap_, version);
+
+    if (!infoReader || !dataReader) {
+        LOGE("Failed to acquire graphics resource readers for version {}",
+               cgl::GetString(version));
+        return nullptr;
+    }
+
+    auto holder = std::make_shared<cgl::py::GraphicsResourceBundleHolder>();
+
+    // query info first
+    cgl::GraphicsResourceSerialNum sn {
+        .version = version,
+        .value = serial_num
+    };
+
+    if (infoReader->query(sn, &holder->info) != cgl::Results::Success) {
+        LOGE("Failed to query graphics info via S/N [{}]", cgl::toStr(sn));
+        return nullptr;
+    }
+
+    if (dataReader->query(holder->info, &holder->data) != cgl::Results::Success) {
+        LOGE("Failed to query graphics data via S/N [{}]", cgl::toStr(sn));
+        return nullptr;
+    }
+
+    return holder;
+}
+
+// -----------------------------------------------------------------------------
 // Define pybind
 // -----------------------------------------------------------------------------
 PYBIND11_MODULE(cgl, m) {
@@ -290,10 +361,12 @@ PYBIND11_MODULE(cgl, m) {
             &Session::acquire_graphics_data_count)
 
         .def(
-            "acquire_graphics_data",
-            [](Session& self,
-               cgl::CrossGateVersion version, size_t idx) -> py::object {
-                auto ptr = self.acquire_graphics_data(version, idx);
+            "acquire_graphics_resource",
+            [](Session&              self,
+               cgl::CrossGateVersion version,
+               uint32_t              serial_num
+            ) -> py::object {
+                auto ptr = self.acquire_graphics_resource(version, serial_num);
                 if (ptr) {
                     return py::cast(ptr);
                 }
@@ -302,8 +375,9 @@ PYBIND11_MODULE(cgl, m) {
 
         .def(
             "acquire_env_palette",
-            [](Session& self,
-               cgl::EnvironmentPaletteTypes envPalette) -> py::object {
+            [](Session&                     self,
+               cgl::EnvironmentPaletteTypes envPalette
+            ) -> py::object {
                 auto ptr = self.acquire_env_palette(envPalette);
                 if (ptr) {
                     return py::cast(ptr);
@@ -320,9 +394,10 @@ PYBIND11_MODULE(cgl, m) {
 
         .def(
             "apply_palette",
-            [](Session& self,
-               std::shared_ptr<cgl::GraphicsResourceData> gfx_data,
-               std::shared_ptr<PaletteData256Holder> palette_data) -> py::object {
+            [](Session&                                   self,
+               cgl::py::GraphicsResourceBundleHolder::Ptr gfx_data,
+               cgl::py::PaletteData256Holder::Ptr         palette_data
+            ) -> py::object {
                 auto img = self.apply_palette(gfx_data.get(), palette_data.get());
                 auto* buffer = new std::vector<uint8_t>(std::move(img));
                 uint8_t* data_ptr = buffer->data();
@@ -332,13 +407,25 @@ PYBIND11_MODULE(cgl, m) {
                 });
 
                 return py::array_t<uint8_t>(
-                    { gfx_data->height, gfx_data->width, 4 },
-                    { gfx_data->width * 4, 4, 1 },
+                    { gfx_data->info.height, gfx_data->info.width, 4 },
+                    { gfx_data->info.width * 4, 4, 1 },
                     data_ptr,
                     free_when_done
                 );
             })
 
+        .def(
+            "acquire_anime_resource",
+            [](Session&              self,
+               cgl::CrossGateVersion version,
+               size_t                serial_num
+            ) -> py::object {
+                auto ptr = self.acquire_anime_resource(version, serial_num);
+                if (ptr) {
+                    return py::cast(ptr);
+                }
+                return py::none();
+            })
         ;
 
     // -------------------------------------------------------------------------
@@ -361,15 +448,56 @@ PYBIND11_MODULE(cgl, m) {
         #undef CGL_X
         .export_values();
 
+    // -------------------------------------------------------------------------
+    // Define cgl::DirectionTypes
+    // -------------------------------------------------------------------------
+    py::enum_<cgl::DirectionTypes>(m, "DirectionTypes", py::arithmetic())
+        #define CGL_X(name) .value(#name, cgl::DirectionTypes::name)
+            CGL_DIRECTION_TYPES_ENUM_FULL_LIST
+        #undef CGL_X
+        .export_values();
 
     // -------------------------------------------------------------------------
-    // Define cgl::CrossGateVersion
+    // Define cgl::MotionTypes
     // -------------------------------------------------------------------------
-    py::class_<cgl::GraphicsResourceData, std::shared_ptr<cgl::GraphicsResourceData>>(m, "GraphicsResourceData")
-        .def_readonly("version", &cgl::GraphicsResourceData::version)
-        .def_readonly("width", &cgl::GraphicsResourceData::width)
-        .def_readonly("height", &cgl::GraphicsResourceData::height);
+    py::enum_<cgl::MotionTypes>(m, "MotionTypes", py::arithmetic())
+        #define CGL_X(name) .value(#name, cgl::MotionTypes::name)
+            CGL_MOTION_TYPES_ENUM_FULL_LIST
+        #undef CGL_X
+        .export_values();
 
-    py::class_<PaletteData256Holder, std::shared_ptr<PaletteData256Holder>>(m, "PaletteData256Holder")
+    // -------------------------------------------------------------------------
+    // Define cgl::GraphicsResourceBundleHolder
+    // -------------------------------------------------------------------------
+    py::class_<cgl::py::GraphicsResourceBundleHolder,
+               cgl::py::GraphicsResourceBundleHolder::Ptr>(m, "GraphicsResourceBundleHolder")
+        .def("offset",
+             &cgl::py::GraphicsResourceBundleHolder::offset,
+             "Return offset as (offsetX, offsetY) in current graphics resource");
+        // .def_readonly("version", &cgl::GraphicsResourceBundleHolder::version)
+        // .def_readonly("width", &cgl::GraphicsResourceBundleHolder::width)
+        // .def_readonly("height", &cgl::GraphicsResourceBundleHolder::height)
+        ;
+
+    // -------------------------------------------------------------------------
+    // Define holders
+    // -------------------------------------------------------------------------
+    py::class_<cgl::py::PaletteData256Holder, cgl::py::PaletteData256Holder::Ptr>(m, "PaletteData256Holder")
         .def(py::init<>());
+
+    py::class_<cgl::py::AnimeResourceDataHolder, cgl::py::AnimeResourceDataHolder::Ptr>(m, "AnimeResourceDataHolder")
+        .def(py::init<>())
+        .def("keys", &cgl::py::AnimeResourceDataHolder::keys)
+        .def("acquire", &cgl::py::AnimeResourceDataHolder::acquire);
+
+    py::class_<cgl::AnimeMotionDesc>(m, "AnimeMotionDesc")
+        .def_readonly("version", &cgl::AnimeMotionDesc::version)
+        .def_readonly("direction", &cgl::AnimeMotionDesc::direction)
+        .def_readonly("motion", &cgl::AnimeMotionDesc::motion)
+        .def_readonly("duration", &cgl::AnimeMotionDesc::duration)
+        .def_readonly("motionGraphicsSerialNums", &cgl::AnimeMotionDesc::motionGraphicsSerialNums)
+        .def("__repr__", [](const cgl::AnimeMotionDesc& desc) {
+            return "<AnimeMotionDesc: " + std::to_string(static_cast<int>(desc.direction)) +
+                   ", " + std::to_string(static_cast<int>(desc.motion)) + ">";
+        });
 }

--- a/python/holders.h
+++ b/python/holders.h
@@ -1,0 +1,68 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2024-2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+#include <vector>
+#include <optional>
+#include <stdexcept>
+#include <memory>
+#include "cgl/resources/resource_types.h"
+#include "cgl/resources/anime_resource.h"
+
+namespace cgl {
+namespace py {
+
+// -----------------------------------------------------------------------------
+struct PaletteData256Holder {
+    using Ptr = std::shared_ptr<cgl::py::PaletteData256Holder>;
+
+    cgl::PaletteData256 data;
+};
+
+
+// -----------------------------------------------------------------------------
+struct GraphicsResourceBundleHolder {
+    using Ptr = std::shared_ptr<cgl::py::GraphicsResourceBundleHolder>;
+
+    cgl::GraphicsResourceInfo info;
+    cgl::GraphicsResourceData data;
+
+    std::pair<int32_t, int32_t> offset () {
+        return std::make_pair(info.offsetX, info.offsetY);
+    }
+};
+
+// -----------------------------------------------------------------------------
+struct AnimeResourceDataHolder {
+    using Ptr = std::shared_ptr<cgl::py::AnimeResourceDataHolder>;
+
+    cgl::AnimeResourceData animeData;
+
+    std::vector<cgl::AnimeDataMapKey> keys() const {
+        std::vector<cgl::AnimeDataMapKey> keys;
+
+        keys.reserve(animeData.motionMap.size());
+        for (const auto& pair : animeData.motionMap) {
+            keys.push_back(pair.first);
+        }
+        return keys;
+    }
+
+    std::optional<cgl::AnimeMotionDesc> acquire(
+        cgl::DirectionTypes dir,
+        cgl::MotionTypes    motion
+    ) const {
+        auto it = animeData.motionMap.find({dir, motion});
+        if (it != animeData.motionMap.end()) {
+            return it->second;
+        }
+        return std::nullopt;
+    }
+};
+
+}   // namespace py
+}   // namespace cgl

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,2 +1,3 @@
 numpy
 gradio
+ninja

--- a/src/resources/anime_resource_data_reader.cpp
+++ b/src/resources/anime_resource_data_reader.cpp
@@ -195,14 +195,14 @@ cgl::Results ReaderImpl::query(
         for (uint32_t i = 0; i < header.frameCount; i++) {
             ss << tempBuffer[i].serialNum << " ";
         }
-        LOGD("motion index [{}], header.direction {}, motion {} duraction {} "
-             "frameCount {} , frames : {}",
-            mIdx,
-            header.direction,
-            header.motion,
-            header.duraction,
-            header.frameCount,
-            ss.str());
+        // LOGD("motion index [{}], header.direction {}, motion {} duraction {} "
+        //      "frameCount {} , frames : {}",
+        //     mIdx,
+        //     header.direction,
+        //     header.motion,
+        //     header.duraction,
+        //     header.frameCount,
+        //     ss.str());
 
 
         // Update description

--- a/src/resources/graphics_resource_file_info_reader.cpp
+++ b/src/resources/graphics_resource_file_info_reader.cpp
@@ -24,7 +24,7 @@ namespace {
 
 #pragma pack(1)
 struct GraphicInfoEntry {
-    int32_t graphicSerialNum;
+    uint32_t graphicSerialNum;
     uint32_t dataOffset;
     uint32_t dataSize;
     int32_t offsetX;
@@ -35,14 +35,14 @@ struct GraphicInfoEntry {
     uint8_t tileY;
     uint8_t passableFlag;
     uint8_t unknown[5];
-    int32_t mapSerialNum;
+    uint32_t mapSerialNum;
 };
 #pragma pack()
 
 
 struct DataRange {
-    int32_t min;
-    int32_t max;
+    uint32_t min;
+    uint32_t max;
 };
 
 

--- a/src/utils/enum_string_helper.cpp
+++ b/src/utils/enum_string_helper.cpp
@@ -6,9 +6,11 @@
 //   All rights reserved.
 // =============================================================================
 
+#include <sstream>
 #include "cgl/core/results.h"
 #include "cgl/core/version.h"
 #include "cgl/resources/resource_types.h"
+#include "cgl/resources/anime_resource.h"
 #include "cgl/utils/enum_string_helper.h"
 
 // -----------------------------------------------------------------------------
@@ -59,4 +61,21 @@ const char* cgl::GetString(const cgl::EnvironmentPaletteTypes& type) {
     default:
         return "Unknown";
     }
+}
+
+// -----------------------------------------------------------------------------
+std::string cgl::toStr(const cgl::GraphicsResourceSerialNum& sn) {
+    std::ostringstream oss;
+    oss << GetString(sn.type)
+        << ":" << GetString(sn.version)
+        << ":" << sn.value;
+    return oss.str();
+}
+
+// -----------------------------------------------------------------------------
+std::string cgl::toStr(const cgl::AnimeResourceSerialNum& sn) {
+    std::ostringstream oss;
+    oss << GetString(sn.version)
+        << ":" << sn.value;
+    return oss.str();
 }


### PR DESCRIPTION
A simple python script for previewing anime data from the classic game Cross Gate using anime, palettes and data provided by the cgl backend module.

It would generate a GIF file with specific anime serial number, such as CG_VERSION_Classic + 101406 :
![anime_DIRECTION_NORTH_ATTACK](https://github.com/user-attachments/assets/d86ab2b2-f9e6-4cb5-9fcf-6926073ed887)

This tool is a debug tool, and might extend to Web viewer in future

- Add `holders.h` to manage the data bundle in cgl py module.
- Use Ninja build