### PR TITLE
Add `engine` module & glfw submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "third_party/spdlog"]
 	path = third_party/spdlog
 	url = https://github.com/gabime/spdlog.git
+[submodule "third_party/glfw"]
+	path = third_party/glfw
+	url = https://github.com/glfw/glfw.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,8 @@ project(${PROJECT_NAME})
 # [Options]
 #-------------------------------------------------------------------------------
 option(CGL_WITH_TEST         "Build with unit tests"                         ON)
-option(CGL_WITH_TOOLS        "Build with binary"                             ON)
+option(CGL_WITH_TOOLS        "Build with tools"                              ON)
+option(CGL_WITH_BINARIES     "Build with binaries"                           ON)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -47,6 +48,7 @@ add_subdirectory(engines/modules/utils)
 add_subdirectory(engines/modules/settings)
 add_subdirectory(engines/modules/trace)
 add_subdirectory(engines/modules/assets)
+add_subdirectory(engines/modules/engine)
 
 add_library(cgl_all INTERFACE)
 add_library(cgl::all ALIAS cgl_all)
@@ -60,8 +62,15 @@ target_link_libraries(cgl_all INTERFACE
 
 
 #-------------------------------------------------------------------------------
-# [build bin]
+# [build tools]
 #-------------------------------------------------------------------------------
 if (CGL_WITH_TOOLS)
     add_subdirectory(tools/python)
+endif()
+
+#-------------------------------------------------------------------------------
+# [build bin]
+#-------------------------------------------------------------------------------
+if (CGL_WITH_BINARIES)
+    add_subdirectory(bin)
 endif()

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cd CrossGate-Legacy
 # Open `x64 Native Tools Command Prompt for VS2022` as command prompt in Windows build
 python -m venv .venv
 .venv\Scripts\activate
-python setup_requirements.py --build_typeRelWithDebInfo
+python setup_requirements.py --build_type RelWithDebInfo
 ```
 
 ### 3. Building CGL

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.16)
+
+# Find all .cpp files in the directory
+file(GLOB_RECURSE SOURCES ${CMAKE_CURRENT_LIST_DIR}/*.cpp)
+
+# Loop through each .cpp file and create an executable
+foreach(SOURCE ${SOURCES})
+    # Extract the file name without the directory and extension
+    get_filename_component(EXE_NAME ${SOURCE} NAME_WE)
+
+    # Create an executable for each .cpp file
+    add_executable(${EXE_NAME} ${SOURCE})
+    target_link_libraries(${EXE_NAME} PRIVATE cgl::all cgl::engine)
+    set_target_properties(${EXE_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CGL_BIN_PATH})
+
+    message(STATUS "Add bin ${EXE_NAME}")
+endforeach()

--- a/bin/cgl-client.cpp
+++ b/bin/cgl-client.cpp
@@ -1,0 +1,20 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+#include "cgl/engine/engine.h"
+
+// -----------------------------------------------------------------------------
+int main(int, char *argv[]) {
+    auto engine = cgl::IEngine::create();
+
+    if (engine != nullptr) {
+        engine->run();
+    }
+
+    return 0;
+}

--- a/engines/modules/common/include/cgl/common/engine.h
+++ b/engines/modules/common/include/cgl/common/engine.h
@@ -1,0 +1,33 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2024-2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+#pragma once
+
+#include <cstdint>
+
+namespace cgl {
+
+#define CGL_ENGINE_STATE_TYPES_VALID_LIST   \
+    CGL_X(RUNNING)                          \
+    CGL_X(SHUTTING_DOWN)                    \
+    CGL_X(FATAL_ERROR)                      \
+
+
+#define CGL_ENGINE_STATE_TYPES_ENUM_FULL_LIST   \
+    CGL_ENGINE_STATE_TYPES_VALID_LIST           \
+    CGL_X(COUNT)                                \
+    CGL_X(UNKNOWN)
+
+
+enum class EngineStateTypes : uint8_t {
+#define CGL_X(name) name,
+    CGL_ENGINE_STATE_TYPES_ENUM_FULL_LIST
+#undef CGL_X
+};
+
+}   // namespace cgl

--- a/engines/modules/common/include/cgl/common/formatters.h
+++ b/engines/modules/common/include/cgl/common/formatters.h
@@ -15,6 +15,7 @@
 #include "cgl/common/motion.h"
 #include "cgl/common/direction.h"
 #include "cgl/common/assets.h"
+#include "cgl/common/input.h"
 
 namespace cgl {
 
@@ -24,6 +25,8 @@ std::string_view ToStr(const cgl::MotionTypes& type);
 std::string_view ToStr(const cgl::DirectionTypes& type);
 std::string_view ToStr(const cgl::EnvironmentPaletteTypes& type);
 std::string_view ToStr(const cgl::GraphicsResourceSerialNumTypes& type);
+std::string_view ToStr(const cgl::MouseButtonTypes& type);
+std::string_view ToStr(const cgl::InputActionTypes& type);
 
 std::string ToStr(const cgl::GraphicsResourceSerialNum& type);
 std::string ToStr(const cgl::AnimeResourceSerialNum& type);

--- a/engines/modules/common/include/cgl/common/input.h
+++ b/engines/modules/common/include/cgl/common/input.h
@@ -1,0 +1,49 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2024-2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+#pragma once
+
+#include <cstdint>
+
+namespace cgl {
+
+#define CGL_MOUSE_BUTTON_TYPES_ENUM_LIST \
+    CGL_X(Left)     \
+    CGL_X(Right)    \
+    CGL_X(Middle)
+
+#define CGL_MOUSE_BUTTON_TYPES_ENUM_LIST_FULL_LIST   \
+    CGL_MOUSE_BUTTON_TYPES_ENUM_LIST                 \
+    CGL_X(Count)                                     \
+    CGL_X(Unknown)
+
+enum class MouseButtonTypes : uint8_t {
+#define CGL_X(name) name,
+    CGL_MOUSE_BUTTON_TYPES_ENUM_LIST_FULL_LIST
+#undef CGL_X
+};
+
+
+#define CGL_INPUT_ACTION_TYPES_ENUM_LIST  \
+    CGL_X(Press)       \
+    CGL_X(Release)     \
+    CGL_X(Repeat)
+
+#define CGL_INPUT_ACTION_TYPES_ENUM_FULL_LIST   \
+    CGL_INPUT_ACTION_TYPES_ENUM_LIST            \
+    CGL_X(Count)                                \
+    CGL_X(Unknown)
+
+enum class InputActionTypes : uint8_t {
+#define CGL_X(name) name,
+    CGL_INPUT_ACTION_TYPES_ENUM_FULL_LIST
+#undef CGL_X
+
+};
+
+}   // namespace cgl

--- a/engines/modules/common/src/formatters.cpp
+++ b/engines/modules/common/src/formatters.cpp
@@ -68,6 +68,28 @@ std::string_view cgl::ToStr(const cgl::DirectionTypes& type) {
 }
 
 // -----------------------------------------------------------------------------
+std::string_view cgl::ToStr(const cgl::MouseButtonTypes& type) {
+    switch (type) {
+#define CGL_X(name) case cgl::MouseButtonTypes::name: return #name;
+        CGL_MOUSE_BUTTON_TYPES_ENUM_LIST_FULL_LIST
+#undef CGL_X
+    default:
+        return "Unknown";
+    }
+}
+
+// -----------------------------------------------------------------------------
+std::string_view cgl::ToStr(const cgl::InputActionTypes& type) {
+    switch (type) {
+#define CGL_X(name) case cgl::InputActionTypes::name: return #name;
+        CGL_INPUT_ACTION_TYPES_ENUM_FULL_LIST
+#undef CGL_X
+    default:
+        return "Unknown";
+    }
+}
+
+// -----------------------------------------------------------------------------
 std::string_view cgl::ToStr(const cgl::EnvironmentPaletteTypes& type) {
     switch (type) {
 #define CGL_X(name) case cgl::EnvironmentPaletteTypes::name: return #name;

--- a/engines/modules/engine/CMakeLists.txt
+++ b/engines/modules/engine/CMakeLists.txt
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 3.16)
+
+set(PROJECT_NAME "cgl_engine")
+set(PROJECT_ALIAS "cgl::engine")
+project(${PROJECT_NAME})
+
+#-------------------------------------------------------------------------------
+# [Dependency check] [google-test]
+#-------------------------------------------------------------------------------
+if (CGL_WITH_TEST)
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    find_package(GTest REQUIRED)
+
+    enable_testing()
+endif()
+
+
+#-------------------------------------------------------------------------------
+# [Dependency check] [glfw]
+#-------------------------------------------------------------------------------
+find_package(glfw3 REQUIRED)
+
+
+#-------------------------------------------------------------------------------
+# [Dependency check] [vulkan]
+#-------------------------------------------------------------------------------
+find_package(Vulkan REQUIRED)
+include_directories(${Vulkan_INCLUDE_DIRS})
+
+#-------------------------------------------------------------------------------
+# [build library]
+#-------------------------------------------------------------------------------
+include_directories(${CMAKE_CURRENT_LIST_DIR}/include)
+include_directories(${CMAKE_CURRENT_LIST_DIR}/src)
+
+file(GLOB_RECURSE LIBRARY_SRC "src/*.cpp")
+
+add_library(${PROJECT_NAME} ${LIBRARY_SRC})
+add_library(${PROJECT_ALIAS} ALIAS ${PROJECT_NAME})
+
+target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_link_libraries(${PROJECT_NAME} PRIVATE glfw cgl::settings cgl::trace cgl::common)
+
+#-------------------------------------------------------------------------------
+# [build Tests]
+#-------------------------------------------------------------------------------
+# if (CGL_WITH_TEST)
+#     add_subdirectory(tests)
+# endif()

--- a/engines/modules/engine/include/cgl/engine/engine.h
+++ b/engines/modules/engine/include/cgl/engine/engine.h
@@ -1,0 +1,29 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+#pragma once
+
+#include <memory>
+#include "string_view"
+
+namespace cgl {
+
+class IEngine {
+ public:
+    using Ptr = std::unique_ptr<IEngine>;
+
+    static cgl::IEngine::Ptr create(const std::string_view setting_path="");
+
+    IEngine() = default;
+
+    virtual ~IEngine() = default;
+
+    virtual void run() = 0;
+};
+
+}   // namespace cgl

--- a/engines/modules/engine/src/client_engine.cpp
+++ b/engines/modules/engine/src/client_engine.cpp
@@ -1,0 +1,91 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+#include "assert.h"
+#include "cgl/settings/settings.h"
+#include "cgl/engine/engine.h"
+#include "cgl/trace/logger.h"
+#include "ecs.h"
+#include "engine_components.h"
+#include "window/window_components.h"
+#include "window/window_init_system.h"
+#include "window/window_input_system.h"
+
+// -----------------------------------------------------------------------------
+namespace {
+
+class ClientEngine : public cgl::IEngine {
+ public:
+    explicit ClientEngine(cgl::SettingsPtr setting);
+
+    ~ClientEngine();
+
+    void run() override;
+
+ private:
+    void init();
+
+    cgl::WindowInitSystem winInitSys_;
+    cgl::WindowInputSystem winInputSys_;
+
+
+    cgl::SettingsPtr setting_;
+    cgl::ECSCore ecs_;
+    cgl::ECSCore& ecs() noexcept { return ecs_; }
+
+};
+
+}   // namespace
+
+
+ClientEngine::ClientEngine(cgl::SettingsPtr setting)
+    : setting_(std::move(setting))  {
+}
+
+ClientEngine::~ClientEngine() {
+}
+
+void ClientEngine::init() {
+    LOGD("Init client engine");
+
+    // append all essential singleton components
+    ecs().addSingleton<cgl::component::EngineState>(
+        cgl::EngineStateTypes::UNKNOWN, "");
+
+    ecs().addSingleton<cgl::component::WindowCreateInfo>(
+        800, 600, "CGL");
+}
+
+void ClientEngine::run() {
+    LOGD("Run client engine");
+    init();
+
+    // init window
+    winInitSys_.update(&ecs_);
+
+    // main loop
+    auto pWinHandle = ecs().getSingleton<cgl::component::WindowHandle>();
+    assert(pWinHandle != nullptr);
+
+    while (pWinHandle->windowShouldClose == false) {
+        winInputSys_.update(&ecs_);
+    }
+}
+
+// -----------------------------------------------------------------------------
+// cgl::IEngine
+cgl::IEngine::Ptr cgl::IEngine::create(const std::string_view setting_path) {
+    auto pSetting = cgl::LoadSettings(setting_path);
+    if (pSetting == nullptr) {
+        LOGE("Failed to load settings from : " << setting_path);
+        return nullptr;
+    }
+    cgl::SetLogLevel(cgl::LogLevel::Trace);
+
+    return std::make_unique<ClientEngine>(std::move(pSetting));
+}

--- a/engines/modules/engine/src/ecs.h
+++ b/engines/modules/engine/src/ecs.h
@@ -1,0 +1,121 @@
+// -----------------------------------------------------------------------------
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2024 MengLun,Cai
+//
+//   All rights reserved.
+//------------------------------------------------------------------------------
+
+#pragma once
+
+#include <cstdint>
+#include <unordered_map>
+#include <unordered_set>
+#include <typeindex>
+#include <any>
+
+namespace cgl {
+
+using Entity = uint32_t;
+
+constexpr Entity FIRST_ENTITY_ID = 1;
+
+class ECSCore final {
+public:
+    ECSCore() : nextEntityId_{cgl::FIRST_ENTITY_ID} {
+
+    }
+
+    ~ECSCore() = default;
+
+    Entity createEntity() {
+        Entity e = nextEntityId_++;
+        entities_.insert(e);
+        return e;
+    }
+
+    void destroyEntity(Entity e) {
+        entities_.erase(e);
+        for (auto& [type, storage] : componentStores_) {
+            storage.erase(e);
+        }
+    }
+
+    template<typename T, typename... Args>
+    void addComponent(Entity e, Args&&... args) {
+        auto& storage = componentStores_[typeid(T)];
+        storage[e] = std::make_any<T>(std::forward<Args>(args)...);
+    }
+
+    template<typename T>
+    void addComponent(Entity e, T value) {
+        auto& storage = componentStores_[typeid(T)];
+        storage[e] = std::make_any<T>(std::move(value));
+    }
+
+    template<typename T>
+    T* getComponent(Entity e = cgl::FIRST_ENTITY_ID) {
+        auto& storage = componentStores_[typeid(T)];
+        return std::any_cast<T>(&storage.at(e));
+    }
+
+    template<typename... Components, typename Func>
+    void gorEach(Func func) {
+        for (auto e : entities_) {
+            if ((hasComponent<Components>(e) && ...)) {
+                func(e, getComponent<Components>(e)...);
+            }
+        }
+    }
+
+    template<typename T, typename... Args>
+    Entity addSingleton(Args&&... args) {
+        // 1. Check for existing singleton and return if found
+        auto type_index = std::type_index(typeid(T));
+        if (singletonEntityMap_.count(type_index)) {
+            return singletonEntityMap_.at(type_index);
+        }
+
+        // 2. CREATE the dedicated entity *internally*
+        Entity singleton_entity = createEntity();
+        
+        // 3. Add the component, passing only the constructor arguments
+        // This calls the correct addComponent(Entity e, Args&&... args)
+        addComponent<T>(singleton_entity, std::forward<Args>(args)...); 
+
+        // 4. Record the mapping
+        singletonEntityMap_[type_index] = singleton_entity;
+        
+        return singleton_entity;
+    }
+
+    template<typename T>
+    T* getSingleton() {
+        auto type_index = std::type_index(typeid(T));
+
+        auto it = singletonEntityMap_.find(type_index);
+        if (it == singletonEntityMap_.end()) {
+            return nullptr;
+        }
+
+        Entity singleton_id = it->second;
+        return getComponent<T>(singleton_id);
+    }
+
+private:
+    template<typename T>
+    bool hasComponent(Entity e) {
+        auto it = componentStores_.find(typeid(T));
+        if (it == componentStores_.end()) return false;
+        return it->second.find(e) != it->second.end();
+    }
+
+    Entity nextEntityId_;
+    std::unordered_set<Entity> entities_;
+    std::unordered_map<std::type_index,
+        std::unordered_map<Entity, std::any> > componentStores_;
+
+    std::unordered_map<std::type_index, Entity> singletonEntityMap_;
+};
+
+}   // namespace cgl

--- a/engines/modules/engine/src/engine_components.h
+++ b/engines/modules/engine/src/engine_components.h
@@ -1,0 +1,28 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+#pragma once
+
+#include <string_view>
+#include "cgl/common/engine.h"
+
+namespace cgl {
+namespace component {
+
+struct EngineState {
+    EngineState() : state(cgl::EngineStateTypes::UNKNOWN) { }
+
+    EngineState(cgl::EngineStateTypes state_, std::string last_error_message_)
+        : state(state), last_error_message(last_error_message_) { }
+
+    cgl::EngineStateTypes state;
+    std::string last_error_message;
+};
+
+}   // namespace component
+}   // namespace cgl

--- a/engines/modules/engine/src/window/window_components.h
+++ b/engines/modules/engine/src/window/window_components.h
@@ -1,0 +1,40 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+#pragma once
+
+#include <string>
+#include "cgl/common/input.h"
+
+namespace cgl {
+namespace component {
+
+struct WindowCreateInfo {
+    int width;
+    int height;
+    std::string title;
+};
+
+struct WindowHandle {
+    void* nativeHandle;     // handle of GLFWwindow
+    bool windowShouldClose;
+};
+
+struct CursorPositionState {
+    float x;
+    float y;
+};
+
+struct MouseInputState {
+    cgl::MouseButtonTypes button;
+    cgl::InputActionTypes inputAction;
+};
+
+
+}   // namespace component
+}   // namespace cgl

--- a/engines/modules/engine/src/window/window_init_system.cpp
+++ b/engines/modules/engine/src/window/window_init_system.cpp
@@ -1,0 +1,64 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+#include <assert.h>
+#define GLFW_INCLUDE_VULKAN
+#include <GLFW/glfw3.h>
+#include "cgl/trace/logger.h"
+#include "ecs.h"
+#include "engine_components.h"
+#include "window/window_components.h"
+#include "window/window_init_system.h"
+
+
+cgl::WindowInitSystem::WindowInitSystem() {
+}
+
+// -----------------------------------------------------------------------------
+void cgl::WindowInitSystem::update(cgl::ECSCore* pECS) {
+    LOGD("WindowInitSystem::update");
+    auto pEngineState = pECS->getSingleton<cgl::component::EngineState>();
+    auto pCreateInfo = pECS->getSingleton<cgl::component::WindowCreateInfo>();
+    assert(pEngineState != nullptr);
+    assert(pCreateInfo != nullptr);
+
+    if (this->createWindow(pCreateInfo) == false) {
+        pEngineState->state = cgl::EngineStateTypes::FATAL_ERROR;
+        pEngineState->last_error_message = "Failed to create window";
+    }
+
+    // Add result handle to ecs
+    pECS->addSingleton<cgl::component::WindowHandle>(window_, false);
+}
+
+// -----------------------------------------------------------------------------
+bool cgl::WindowInitSystem::createWindow(
+    const cgl::component::WindowCreateInfo* pCreateInfo
+) {
+    if (glfwInit() != GLFW_TRUE) {
+        LOGE("Failed in glfwInit()");
+        return false;
+    }
+
+    LOGD("Create window with size (" << pCreateInfo->width
+         << "x" << pCreateInfo->height << "), title :" << pCreateInfo->title);
+
+    glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+    glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);
+    window_ = glfwCreateWindow(pCreateInfo->width,
+                               pCreateInfo->height,
+                               pCreateInfo->title.c_str(),
+                               nullptr,
+                               nullptr);
+    if (window_ == nullptr) {
+        LOGE("Failed to create window with size (" << pCreateInfo->width
+             << " x " << pCreateInfo->height
+             << "), title :" << pCreateInfo->title);
+        return false;
+    }
+    return true;
+}

--- a/engines/modules/engine/src/window/window_init_system.h
+++ b/engines/modules/engine/src/window/window_init_system.h
@@ -1,0 +1,36 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+#pragma once
+
+#include <memory>
+
+struct GLFWwindow;
+
+namespace cgl {
+
+class ECSCore;
+
+namespace component {
+struct WindowCreateInfo;
+}   // namespace component
+
+class WindowInitSystem {
+public:
+    WindowInitSystem();
+
+    ~WindowInitSystem() = default;
+
+    void update(cgl::ECSCore* pECS);
+
+ private:
+    bool createWindow(const cgl::component::WindowCreateInfo* pCreateInfo);
+    GLFWwindow *window_;
+};
+
+}   // namespace cgl

--- a/engines/modules/engine/src/window/window_input_system.cpp
+++ b/engines/modules/engine/src/window/window_input_system.cpp
@@ -1,0 +1,136 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+#include <assert.h>
+#define GLFW_INCLUDE_VULKAN
+#include <GLFW/glfw3.h>
+#include "cgl/common/input.h"
+#include "cgl/common/formatters.h"
+#include "cgl/trace/logger.h"
+#include "ecs.h"
+#include "engine_components.h"
+#include "window/window_components.h"
+#include "window/window_input_system.h"
+
+
+// -----------------------------------------------------------------------------
+namespace {
+
+cgl::MouseButtonTypes fromGLFWMouseButton(int32_t glfw_mouse_button_value) {
+    switch (glfw_mouse_button_value) {
+    case GLFW_MOUSE_BUTTON_LEFT:
+        return cgl::MouseButtonTypes::Left;
+    case GLFW_MOUSE_BUTTON_RIGHT:
+        return cgl::MouseButtonTypes::Right;
+    case GLFW_MOUSE_BUTTON_MIDDLE:
+        return cgl::MouseButtonTypes::Middle;
+    default:
+        return cgl::MouseButtonTypes::Unknown;
+    }
+}
+
+cgl::InputActionTypes fromGLFWInputAction(int32_t glfw_action_value) {
+    switch (glfw_action_value) {
+    case GLFW_PRESS:
+        return cgl::InputActionTypes::Press;
+    case GLFW_RELEASE:
+        return cgl::InputActionTypes::Release;
+    case GLFW_REPEAT:
+        return cgl::InputActionTypes::Repeat;
+    default:
+        return cgl::InputActionTypes::Unknown;
+    }
+}
+
+}   // namespace
+
+// -----------------------------------------------------------------------------
+cgl::WindowInputSystem::WindowInputSystem()
+    : cursorPosState_{} {
+    updater_ = &WindowInputSystem::init;
+}
+
+// -----------------------------------------------------------------------------
+void cgl::WindowInputSystem::update(cgl::ECSCore* pECS) {
+    (this->*updater_)(pECS);
+}
+
+// -----------------------------------------------------------------------------
+void cgl::WindowInputSystem::init(cgl::ECSCore* pECS) {
+    LOGD("WindowInitSystem::init");
+    auto pEngineState = pECS->getSingleton<cgl::component::EngineState>();
+    auto pWinHandle = pECS->getSingleton<cgl::component::WindowHandle>();
+    assert(pEngineState != nullptr);
+    assert(pWinHandle != nullptr);
+
+    GLFWwindow* pWindow = static_cast<GLFWwindow *>(pWinHandle->nativeHandle);
+    glfwSetWindowUserPointer(pWindow, this);
+    glfwSetCursorPosCallback(pWindow, cursorPosCb);
+    glfwSetMouseButtonCallback(pWindow, mouseButtonCb);
+
+    updater_ = &WindowInputSystem::updateEvents;
+}
+
+// -----------------------------------------------------------------------------
+void cgl::WindowInputSystem::updateEvents(cgl::ECSCore* pECS) {
+    auto pEngineState = pECS->getSingleton<cgl::component::EngineState>();
+    auto pWinHandle   = pECS->getSingleton<cgl::component::WindowHandle>();
+    assert(pEngineState != nullptr);
+    assert(pWinHandle != nullptr);
+
+    GLFWwindow* pWindow = static_cast<GLFWwindow *>(pWinHandle->nativeHandle);
+    if (glfwWindowShouldClose(pWindow) > 0) {
+        LOGD("Window closed ...");
+        pWinHandle->windowShouldClose = true;
+        return;
+    }
+
+    glfwPollEvents();
+
+    // check cursor pos updated or not
+    float x = cursorPosState_[0].x;
+    float y = cursorPosState_[0].y;
+    float dx = x - cursorPosState_[1].x;
+    float dy = y - cursorPosState_[1].y;
+    if (dx != 0.0f || dy != 0.0f) {
+        cursorPosState_[1].x = x;
+        cursorPosState_[1].y = y;
+    }
+}
+
+// -----------------------------------------------------------------------------
+void cgl::WindowInputSystem::cursorPosCb(
+    GLFWwindow* pWindow,
+    double      xpos,
+    double      ypos
+) {
+    auto userPtr = glfwGetWindowUserPointer(pWindow);
+    auto thiz = static_cast<cgl::WindowInputSystem*>(userPtr);
+
+    float x = static_cast<float>(xpos);
+    float y = static_cast<float>(ypos);
+    thiz->cursorPosState_[0].x = x;
+    thiz->cursorPosState_[0].y = y;
+}
+
+// -----------------------------------------------------------------------------
+void cgl::WindowInputSystem::mouseButtonCb(
+    GLFWwindow* pWindow,
+    int         button,
+    int         action,
+    int         mods
+) {
+    auto userPtr = glfwGetWindowUserPointer(pWindow);
+    auto thiz = static_cast<cgl::WindowInputSystem*>(userPtr);
+
+    cgl::component::MouseInputState inputState {
+        .button      = fromGLFWMouseButton(button),
+        .inputAction = fromGLFWInputAction(action)
+    };
+    LOGD("MouseInput " << inputState.button << " , " << inputState.inputAction);
+}

--- a/engines/modules/engine/src/window/window_input_system.h
+++ b/engines/modules/engine/src/window/window_input_system.h
@@ -1,0 +1,49 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+#pragma once
+
+#include <memory>
+#include <functional>
+#include "window/window_components.h"
+
+// -----------------------------------------------------------------------------
+// forward declaration
+struct GLFWwindow;
+
+namespace cgl {
+
+class ECSCore;
+
+}   // namespace cgl
+
+// -----------------------------------------------------------------------------
+namespace cgl {
+
+class WindowInputSystem {
+public:
+    WindowInputSystem();
+
+    ~WindowInputSystem() = default;
+
+    void update(cgl::ECSCore* pECS);
+
+ private:
+    bool sysInited_;
+    void init(cgl::ECSCore* pECS);
+    void updateEvents(cgl::ECSCore* pECS);
+
+    using UpdateFunc = void (WindowInputSystem::*)(cgl::ECSCore*);
+    UpdateFunc updater_;
+
+    static void cursorPosCb(GLFWwindow* pWindow, double x, double y);
+    static void mouseButtonCb(GLFWwindow* pWindow, int btn, int act, int);
+    cgl::component::CursorPositionState cursorPosState_[2];
+};
+
+}   // namespace cgl

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -50,7 +50,7 @@ def build_cmake_depend(workspace, build_type, depend_name, *cmake_args):
 
 # ----------------------------------------------------------------------------------------------------------------------
 def install_python_requirements(workspace):
-    requirements_path = os.path.join(workspace, "python", "requirements.txt")
+    requirements_path = os.path.join(workspace, "tools", "python", "requirements.txt")
     run_cmd([
         sys.executable, "-m", "pip", "install", "-r", requirements_path])
 
@@ -80,6 +80,12 @@ def main(args):
 
     build_cmake_depend(workspace, args.build_type,
                        "spdlog")
+
+    build_cmake_depend(workspace, args.build_type,
+                       "glfw",
+                       "-DGLFW_BUILD_DOCS=OFF",
+                       "-DGLFW_BUILD_EXAMPLES=OFF",
+                       "-DGLFW_BUILD_TESTS=OFF")
 
 # ----------------------------------------------------------------------------------------------------------------------
 if __name__ == "__main__":


### PR DESCRIPTION
Add `engine` module & glfw submodule

- engine module will used for bin and as key module for cross gate client.
- All engine will try to use ECS based system to construct it.
- Add glfw submodule. 