### PR TITLE
Add basic assets system imple to init assets readers.

### DIFF
--- a/engines/modules/common/include/cgl/common/enum_array.h
+++ b/engines/modules/common/include/cgl/common/enum_array.h
@@ -1,0 +1,28 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+#pragma once
+
+#include <cstdint>
+
+namespace cgl {
+
+template <typename Enum, typename T>
+struct EnumArray {
+    static constexpr size_t COUNT = static_cast<size_t>(Enum::COUNT);
+    std::array<T, COUNT> data;
+
+    constexpr T& operator[](Enum e) noexcept {
+        return data[static_cast<size_t>(e)];
+    }
+    constexpr const T& operator[](Enum e) const noexcept {
+        return data[static_cast<size_t>(e)];
+    }
+};
+
+}   // namespace cgl

--- a/engines/modules/common/include/cgl/common/states.h
+++ b/engines/modules/common/include/cgl/common/states.h
@@ -13,21 +13,22 @@
 namespace cgl {
 
 // -----------------------------------------------------------------------------
-#define CGL_STATE_TYPES_VALID_LIST    \
-    CGL_X(UNINITIALIZED)                    \
-    CGL_X(INITIALIZING)                     \
-    CGL_X(INITIALIZED)                      \
-    CGL_X(RUNNING)                          \
-    CGL_X(ACTIVE)                           \
-    CGL_X(UNLOADING)                        \
-    CGL_X(SHUTTING_DOWN)                    \
-    CGL_X(SHUTDOWN)                         \
-    CGL_X(RELEASE)                          \
-    CGL_X(ERROR)                            \
+#define CGL_STATE_TYPES_VALID_LIST  \
+    CGL_X(UNINITIALIZED)            \
+    CGL_X(INITIALIZING)             \
+    CGL_X(INITIALIZED)              \
+    CGL_X(RUNNING)                  \
+    CGL_X(ACTIVE)                   \
+    CGL_X(UNLOADING)                \
+    CGL_X(SHUTTING_DOWN)            \
+    CGL_X(SHUTDOWN)                 \
+    CGL_X(RELEASE)                  \
+    CGL_X(FINISH)                   \
+    CGL_X(ERROR)                    \
 
 #define CGL_STATE_TYPES_ENUM_FULL_LIST    \
     CGL_STATE_TYPES_VALID_LIST            \
-    CGL_X(COUNT)                                \
+    CGL_X(COUNT)                          \
     CGL_X(UNKNOWN)
 
 enum class StateTypes : uint8_t {

--- a/engines/modules/engine/CMakeLists.txt
+++ b/engines/modules/engine/CMakeLists.txt
@@ -39,7 +39,7 @@ add_library(${PROJECT_NAME} ${LIBRARY_SRC})
 add_library(${PROJECT_ALIAS} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_link_libraries(${PROJECT_NAME} PRIVATE glfw cgl::render cgl::settings cgl::trace cgl::common Vulkan::Vulkan)
+target_link_libraries(${PROJECT_NAME} PRIVATE glfw cgl::assets cgl::render cgl::settings cgl::trace cgl::common Vulkan::Vulkan)
 
 #-------------------------------------------------------------------------------
 # [build Tests]

--- a/engines/modules/engine/src/assets/assets_components.h
+++ b/engines/modules/engine/src/assets/assets_components.h
@@ -1,0 +1,44 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+#pragma once
+
+#include <memory>
+#include "cgl/common/states.h"
+#include "cgl/common/version.h"
+#include "cgl/common/enum_array.h"
+#include "cgl/assets/graphics_info_reader.h"
+#include "cgl/assets/graphics_data_reader.h"
+#include "cgl/assets/anime_info_reader.h"
+#include "cgl/assets/anime_data_reader.h"
+#include "cgl/assets/palette_reader.h"
+
+namespace cgl {
+namespace component {
+
+struct AssetsReaderState {
+    cgl::StateTypes state;
+    std::string lastError;
+
+    cgl::EnumArray<cgl::CrossGateVersion,
+                   cgl::IAnimeDataReader::Ptr> pAnimeDataReader;
+
+    cgl::EnumArray<cgl::CrossGateVersion,
+                   cgl::IAnimeInfoReader::Ptr> pAnimeInfoReader;
+
+    cgl::EnumArray<cgl::CrossGateVersion,
+                   cgl::IGraphicsDataReader::Ptr> pGfxDataReader;
+
+    cgl::EnumArray<cgl::CrossGateVersion,
+                   cgl::IGraphicsInfoReader::Ptr> pGfxInfoReader;
+
+    cgl::IPaletteReader::Ptr pPaletteReader;
+};
+
+}   // namespace component
+}   // namespace cgl

--- a/engines/modules/engine/src/assets/assets_reader_init_system.cpp
+++ b/engines/modules/engine/src/assets/assets_reader_init_system.cpp
@@ -1,0 +1,194 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+#include <memory>
+#include <array>
+#include "cgl/trace/logger.h"
+#include "cgl/common/formatters.h"
+#include "engine/ecs.h"
+#include "engine/error_system.h"
+#include "engine/engine_components.h"
+#include "assets/assets_components.h"
+#include "assets/assets_system.h"
+
+using cgl::component::EngineState;
+using cgl::component::AssetsReaderState;
+
+// -----------------------------------------------------------------------------
+namespace {
+
+#define CGL_X(name) cgl::CrossGateVersion::name,
+static std::vector<cgl::CrossGateVersion> CGL_VERSIONS {
+        CGL_VERSION_TYPES_VALID_LIST
+    };
+#undef CGL_X
+
+// -----------------------------------------------------------------------------
+template<typename ReaderT>
+std::future<typename ReaderT::Ptr>
+LaunchInitReaderAsyncTask(
+    cgl::Settings*        pSettings,
+    cgl::CrossGateVersion version
+) {
+    return std::async(
+        std::launch::async,
+        [pSettings, version]() -> ReaderT::Ptr {
+            auto p = ReaderT::create({
+                .pSettings = pSettings,
+                .version   = version,
+            });
+            if (!p || p->load() != cgl::Results::Success) {
+                return nullptr;
+            }
+            return p;
+        }
+    );
+}
+
+// -----------------------------------------------------------------------------
+template<typename T>
+bool IsFutureReady(
+    std::future<T>& future,
+    bool* anyFail
+) {
+    const auto timeout = std::chrono::seconds(0);
+    if (future.valid() == false) {
+        *anyFail = true;
+        LOGE("future is invalid");
+        return false;
+    }
+    if (future.wait_for(timeout) != std::future_status::ready) {
+        return false;
+    }
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+template<typename T>
+bool IsFuturesAllReady(
+    std::vector<std::future<T>>& futures,
+    bool* anyFail
+) {
+    const auto timeout = std::chrono::seconds(0);
+    for (auto& future : futures) {
+        if (IsFutureReady(future, anyFail) == false) {
+            return false;
+        }
+    }
+    return true;
+}
+
+}   // namespace
+
+// -----------------------------------------------------------------------------
+cgl::AssetsReaderInitSystem::AssetsReaderInitSystem() {
+    updater_ = &AssetsReaderInitSystem::initStage;
+}
+
+// -----------------------------------------------------------------------------
+void cgl::AssetsReaderInitSystem::initStage(cgl::ECSCore* pECS) {
+    LOGD("Launch tasks to init assets readers");
+
+    auto pEngineState   = pECS->getSingleton<EngineState>();
+    pAssetsReaderState_ = pECS->getSingleton<AssetsReaderState>();
+    assert(pEngineState != nullptr);
+    assert(pAssetsReaderState_ != nullptr);
+
+    pAssetsReaderState_->state = cgl::StateTypes::INITIALIZING;
+    futures_IAnimeInfoReader_.resize(CGL_VERSIONS.size());
+    futures_IAnimeDataReader_.resize(CGL_VERSIONS.size());
+    futures_IGraphicsDataReader_.resize(CGL_VERSIONS.size());
+    futures_IGraphicsInfoReader_.resize(CGL_VERSIONS.size());
+
+    // create task to init reader in background
+    auto pSettings = pEngineState->settings.get();
+
+    for (const auto version : CGL_VERSIONS) {
+        LOGD("Launch tasks to init readers for: " << version);
+        const auto idx = static_cast<size_t>(version);
+        futures_IAnimeInfoReader_[idx] = LaunchInitReaderAsyncTask<
+            cgl::IAnimeInfoReader>(pSettings, version);
+
+        futures_IAnimeDataReader_[idx] = LaunchInitReaderAsyncTask<
+            cgl::IAnimeDataReader>(pSettings, version);
+
+        futures_IGraphicsInfoReader_[idx] = LaunchInitReaderAsyncTask<
+            cgl::IGraphicsInfoReader>(pSettings, version);
+
+        futures_IGraphicsDataReader_[idx] = LaunchInitReaderAsyncTask<
+            cgl::IGraphicsDataReader>(pSettings, version);
+    }
+
+    futures_IPaletteReader_ = std::async(
+        std::launch::async,
+        [pSettings]() -> cgl::IPaletteReader::Ptr {
+            auto p = cgl::IPaletteReader::create({
+                .pSettings = pSettings,
+            });
+            if (p == nullptr)
+                return nullptr;
+            return p;
+        }
+    );
+
+    // swtich to next stage
+    pAssetsReaderState_->state = cgl::StateTypes::RUNNING;
+    updater_ = &AssetsReaderInitSystem::checkStage;
+}
+
+// -----------------------------------------------------------------------------
+void cgl::AssetsReaderInitSystem::checkStage(cgl::ECSCore* pECS) {
+    bool anyFail = false;
+
+    // check all futures all ready?
+    if ((IsFuturesAllReady(futures_IAnimeInfoReader_, &anyFail) == false) ||
+        (IsFuturesAllReady(futures_IAnimeDataReader_, &anyFail) == false) ||
+        (IsFuturesAllReady(futures_IGraphicsInfoReader_, &anyFail) == false) ||
+        (IsFuturesAllReady(futures_IGraphicsDataReader_, &anyFail) == false) ||
+        (IsFutureReady(futures_IPaletteReader_, &anyFail) == false)) {
+        if (anyFail) {
+            cgl::RaiseError(pAssetsReaderState_,
+                "One of future in reader init task is invalid.");
+            return;
+        }
+        return;
+    }
+
+    // move all readers to the state after all ready.
+    LOGI("All assets reader initialization tasks ready");
+
+    for (const auto version : CGL_VERSIONS) {
+        const auto idx = static_cast<size_t>(version);
+        pAssetsReaderState_->pAnimeInfoReader[version]
+            = futures_IAnimeInfoReader_[idx].get();
+
+        pAssetsReaderState_->pAnimeDataReader[version]
+            = futures_IAnimeDataReader_[idx].get();
+
+        pAssetsReaderState_->pGfxDataReader[version]
+            = futures_IGraphicsDataReader_[idx].get();
+
+        pAssetsReaderState_->pGfxInfoReader[version]
+            = futures_IGraphicsInfoReader_[idx].get();
+    }
+    pAssetsReaderState_->pPaletteReader = futures_IPaletteReader_.get();
+
+    // swtich to next stage
+    pAssetsReaderState_->state = cgl::StateTypes::FINISH;
+    updater_ = &AssetsReaderInitSystem::nopStage;
+}
+
+// -----------------------------------------------------------------------------
+void cgl::AssetsReaderInitSystem::nopStage(cgl::ECSCore* pECS) {
+    // NOP
+}
+
+// -----------------------------------------------------------------------------
+void cgl::AssetsReaderInitSystem::update(cgl::ECSCore* pECS) {
+    (this->*updater_)(pECS);
+}

--- a/engines/modules/engine/src/assets/assets_system.h
+++ b/engines/modules/engine/src/assets/assets_system.h
@@ -1,0 +1,54 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+#pragma once
+
+#include <vector>
+#include <future>
+#include "assets/assets_components.h"
+
+// -----------------------------------------------------------------------------
+namespace cgl {
+
+class ECSCore;
+
+// -----------------------------------------------------------------------------
+class AssetsReaderInitSystem {
+ public:
+    AssetsReaderInitSystem();
+
+    ~AssetsReaderInitSystem() = default;
+
+    void update(cgl::ECSCore* pECS);
+
+ private:
+    void initStage(cgl::ECSCore* pECS);
+    void checkStage(cgl::ECSCore* pECS);
+    void nopStage(cgl::ECSCore* pECS);
+
+    using UpdateFunc = void (AssetsReaderInitSystem::*)(cgl::ECSCore*);
+    UpdateFunc updater_;
+
+    std::vector<std::future<
+        cgl::IAnimeInfoReader::Ptr>> futures_IAnimeInfoReader_;
+
+    std::vector<std::future<
+        cgl::IAnimeDataReader::Ptr>> futures_IAnimeDataReader_;
+
+    std::vector<std::future<
+        cgl::IGraphicsDataReader::Ptr>> futures_IGraphicsDataReader_;
+
+    std::vector<std::future<
+        cgl::IGraphicsInfoReader::Ptr>> futures_IGraphicsInfoReader_;
+
+    std::future<cgl::IPaletteReader::Ptr> futures_IPaletteReader_;
+
+    cgl::component::AssetsReaderState* pAssetsReaderState_;
+};
+
+}   // namespace cgl

--- a/engines/modules/engine/src/engine/client_engine.cpp
+++ b/engines/modules/engine/src/engine/client_engine.cpp
@@ -12,6 +12,7 @@
 #include "cgl/trace/logger.h"
 #include "engine/ecs.h"
 #include "engine/engine_components.h"
+#include "assets/assets_components.h"
 #include "window/window_components.h"
 #include "window/window_systems.h"
 #include "render/render_components.h"
@@ -63,8 +64,14 @@ ClientEngine::~ClientEngine() {
 void ClientEngine::init() {
     LOGI("Init client engine");
 
-    // append all essential singleton components
-    ecs().addSingleton<cgl::component::EngineState>();
+    // add engine state
+    auto pSettings = cgl::LoadSettings("settings.ini");
+    if (pSettings == nullptr) {
+        LOGW("Failed to to the setting file, use default setting for the engine");
+        pSettings = cgl::LoadSettings();
+    }
+    ecs().addSingleton<cgl::component::EngineState>(
+        cgl::StateTypes::UNKNOWN, "", std::move(pSettings));
 
     // add window state
     ecs().addSingleton<cgl::component::WindowState>(
@@ -76,11 +83,16 @@ void ClientEngine::init() {
         cgl::StateTypes::UNKNOWN, cgl::SceneTypes::Unknown, nullptr, "");
     pSceneState_ = ecs().getSingleton<cgl::component::SceneState>();
 
+    // add assets reader state
+    ecs().addSingleton<cgl::component::AssetsReaderState>(
+        cgl::StateTypes::UNKNOWN, "");
+
     // add render state
     ecs().addSingleton<cgl::component::RenderState>(
         cgl::StateTypes::UNKNOWN, "");
     pRenderState_ = ecs().getSingleton<cgl::component::RenderState>();
 
+    // add window create info
     ecs().addSingleton<cgl::component::WindowCreateInfo>(
         800, 600, "CGL");
 }

--- a/engines/modules/engine/src/engine/engine_components.h
+++ b/engines/modules/engine/src/engine/engine_components.h
@@ -8,16 +8,17 @@
 
 #pragma once
 
-#include <string_view>
+#include <string>
 #include "cgl/common/states.h"
+#include "cgl/settings/settings.h"
 
 namespace cgl {
 namespace component {
 
 struct EngineState {
-    EngineState() : state(cgl::StateTypes::UNKNOWN) {}
     cgl::StateTypes state;
     std::string lastError;
+    cgl::Settings::Ptr settings;
 };
 
 }   // namespace component

--- a/engines/modules/engine/src/scene/init_scene/init_scene.cpp
+++ b/engines/modules/engine/src/scene/init_scene/init_scene.cpp
@@ -6,13 +6,16 @@
 //   All rights reserved.
 // =============================================================================
 
-#include "assert.h"
+#include <assert.h>
 #include <memory>
 #include "cgl/trace/logger.h"
-#include "render/render_components.h"
-#include "scene/scene_components.h"
 #include "engine/ecs.h"
+#include "render/render_components.h"
+#include "assets/assets_system.h"
+#include "scene/scene_components.h"
 #include "scene/init_scene/init_scene_systems.h"
+
+using cgl::component::AssetsReaderState;
 
 // -----------------------------------------------------------------------------
 namespace {
@@ -31,6 +34,8 @@ class InitScene : public cgl::IScene {
 
  private:
     cgl::InitSceneRenderSystem renderSys_;
+    cgl::AssetsReaderInitSystem assetsReaderInitSys_;
+    cgl::component::AssetsReaderState* pAssetsReaderState_;
 };
 
 }   // namespace
@@ -42,8 +47,12 @@ InitScene::InitScene()
 }
 
 void InitScene::onEnter(cgl::ECSCore* pECS) noexcept {
+    pAssetsReaderState_ = pECS->getSingleton<AssetsReaderState>();
+    assert(pAssetsReaderState_ != nullptr);
+
     cgl::InitSceneInitRenderSystem initRenderSys;
     initRenderSys.update(pECS);
+    assetsReaderInitSys_.update(pECS);
 }
 
 void InitScene::onExit(cgl::ECSCore* pECS) noexcept {
@@ -56,7 +65,7 @@ void InitScene::update(cgl::ECSCore* pECS) noexcept {
     renderSys_.update(pECS);
 
     // check resource init finish
-    
+    assetsReaderInitSys_.update(pECS);
 }
 
 // -----------------------------------------------------------------------------

--- a/engines/modules/settings/generate_settings.py
+++ b/engines/modules/settings/generate_settings.py
@@ -78,6 +78,7 @@ namespace _runtime_settings {
     #----------------------------------------------------------------------------
     def generate_setting_struct(self, settings):
         self.append("struct Settings {")
+        self.append("using Ptr = std::unique_ptr<cgl::Settings>;")
 
         # append equality operator
         self.append(f"    bool operator==(const cgl::Settings& other) const;")


### PR DESCRIPTION
Add basic assets system imple to init assets readers.

The AssetsReaderInitSystem will async load all avaible assets readers and the caller (such as InitScene) must polling the `AssetsReaderState` to check the init finish or not.

In this submit, the InitScene doesn't check the status result but just launch the `AssetsReaderInitSystem` to load all readers.