### PR TITLE
Add templated Vector class and dot() utility function

### DIFF
--- a/engines/modules/common/include/cgl/common/vector.h
+++ b/engines/modules/common/include/cgl/common/vector.h
@@ -1,0 +1,107 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+#pragma once
+
+#include <array>
+
+namespace cgl {
+
+// -----------------------------------------------------------------------------
+template <int N, typename T>
+class Vector {
+ public:
+    Vector() : data_() { }
+
+    template<typename... Args>
+    Vector(Args... args) : data_({static_cast<T>(args)...}) {
+        static_assert(sizeof...(Args) <= N,
+                      "Too many arguments for Vector constructor.");
+    }
+
+    Vector(const Vector&) = default;
+
+    ~Vector() = default;
+
+    Vector& operator=(const Vector&) = default;
+
+    T& operator[](int i) noexcept {
+        return data_[i];
+    }
+
+    const T& operator[](int i) const noexcept {
+        return data_[i];
+    }
+
+    Vector<N, T> operator+(const Vector<N, T>& other) const {
+        Vector<N, T> result;
+        for (int i = 0; i < N; ++i) {
+            result.data_[i] = data_[i] + other.data_[i];
+        }
+        return result;
+    }
+
+    Vector<N, T> operator-(const Vector<N, T>& other) const {
+        Vector<N, T> result;
+        for (int i = 0; i < N; ++i) {
+            result.data_[i] = data_[i] - other.data_[i];
+        }
+        return result;
+    }
+
+    Vector<N, T> operator*(T v) const {
+        Vector<N, T> result;
+        for (int i = 0; i < N; ++i) {
+            result.data_[i] = data_[i] * v;
+        }
+        return result;
+    }
+
+    Vector<N, T> operator/(T v) const {
+        Vector<N, T> result;
+        for (int i = 0; i < N; ++i) {
+            result.data_[i] = data_[i] / v;
+        }
+        return result;
+    }
+
+    const T* data() const noexcept {
+        return data_.data();
+    }
+
+ private:
+    std::array<T, N> data_;
+};
+
+using Vec2f = cgl::Vector<2, float>;
+using Vec3f = cgl::Vector<3, float>;
+using Vec4f = cgl::Vector<4, float>;
+using Vec2i = cgl::Vector<2, int>;
+using Vec3i = cgl::Vector<3, int>;
+using Vec4i = cgl::Vector<4, int>;
+
+using Point2f = cgl::Vec2f;
+using Point3f = cgl::Vec3f;
+using Point4f = cgl::Vec4f;
+using Point2i = cgl::Vec2i;
+using Point3i = cgl::Vec3i;
+using Point4i = cgl::Vec4i;
+
+// -----------------------------------------------------------------------------
+template <int N, typename T>
+inline T dot(const cgl::Vector<N, T>& a, const cgl::Vector<N, T>& b) {
+    T result = T(0);
+    for (int i = 0; i < N; ++i) {
+        result += a[i] * b[i];
+    }
+    return result;
+}
+
+// -----------------------------------------------------------------------------
+
+}   // namespace cgl

--- a/engines/modules/common/tests/test_vector.cpp
+++ b/engines/modules/common/tests/test_vector.cpp
@@ -1,0 +1,99 @@
+// =============================================================================
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2025 MengLun,Cai
+//
+//   All rights reserved.
+// =============================================================================
+
+#include <gtest/gtest.h>
+#include "cgl/common/vector.h"
+
+// -----------------------------------------------------------------------------
+TEST(common_vector_test, ConstructorAndAccess) {
+    // constructor test
+    cgl::Vec3f v(1.0f, 2.0f, 3.0f);
+    EXPECT_FLOAT_EQ(v[0], 1.0f);
+    EXPECT_FLOAT_EQ(v[1], 2.0f);
+    EXPECT_FLOAT_EQ(v[2], 3.0f);
+
+    // zero vector test
+    cgl::Vec4i v_zero;
+    EXPECT_EQ(v_zero[0], 0);
+    EXPECT_EQ(v_zero[3], 0);
+
+    // Testing constructors with parameters, missing items are zero-initialized.
+    cgl::Vector<4, float> v_partial(5.0f, 6.0f);
+    EXPECT_FLOAT_EQ(v_partial[0], 5.0f);
+    EXPECT_FLOAT_EQ(v_partial[1], 6.0f);
+    EXPECT_FLOAT_EQ(v_partial[2], 0.0f);
+}
+
+// -----------------------------------------------------------------------------
+TEST(common_vector_test, AdditionAndSubtraction) {
+    cgl::Vec3f a(1.0f, 2.0f, 3.0f);
+    cgl::Vec3f b(5.0f, 1.0f, -2.0f);
+
+    // test add
+    cgl::Vec3f sum = a + b;
+    EXPECT_FLOAT_EQ(sum[0], 6.0f);
+    EXPECT_FLOAT_EQ(sum[1], 3.0f);
+    EXPECT_FLOAT_EQ(sum[2], 1.0f);
+
+    // test sub
+    cgl::Vec3f diff = a - b;
+    EXPECT_FLOAT_EQ(diff[0], -4.0f);
+    EXPECT_FLOAT_EQ(diff[1], 1.0f);
+    EXPECT_FLOAT_EQ(diff[2], 5.0f);
+}
+
+// -----------------------------------------------------------------------------
+TEST(common_vector_test, ScalarMultiplicationAndDivision) {
+    cgl::Vec3f v(2.0f, 4.0f, 8.0f);
+    float scalar = 2.0f;
+
+    // test scalar multiplication
+    cgl::Vec3f multiplied = v * scalar;
+    EXPECT_FLOAT_EQ(multiplied[0], 4.0f);
+    EXPECT_FLOAT_EQ(multiplied[1], 8.0f);
+    EXPECT_FLOAT_EQ(multiplied[2], 16.0f);
+
+    // test scalar division
+    cgl::Vec3f divided = v / scalar;
+    EXPECT_FLOAT_EQ(divided[0], 1.0f);
+    EXPECT_FLOAT_EQ(divided[1], 2.0f);
+    EXPECT_FLOAT_EQ(divided[2], 4.0f);
+
+    // test int type
+    cgl::Vec2i i_v(10, 20);
+    cgl::Vec2i i_mult = i_v * 5;
+    EXPECT_EQ(i_mult[0], 50);
+    EXPECT_EQ(i_mult[1], 100);
+}
+
+// -----------------------------------------------------------------------------
+TEST(common_vector_test, DotProduct) {
+    cgl::Vec3f a(1.0f, 2.0f, 3.0f);
+    cgl::Vec3f b(4.0f, 5.0f, 6.0f);
+    // excepted: (1*4) + (2*5) + (3*6) = 4 + 10 + 18 = 32.0
+
+    float result = dot(a, b);
+    EXPECT_FLOAT_EQ(result, 32.0f);
+
+    // test Orthogonal vectors (dot = 0)
+    cgl::Vec2f c(1.0f, 0.0f);
+    cgl::Vec2f d(0.0f, 1.0f);
+    EXPECT_FLOAT_EQ(dot(c, d), 0.0f);
+
+    // neg value test
+    cgl::Vec3f e(-1.0f, 0.0f, -2.0f);
+    cgl::Vec3f f(1.0f, 0.0f, 2.0f);
+    // (-1*1) + (0*0) + (-2*2) = -1 + 0 - 4 = -5.0
+    EXPECT_FLOAT_EQ(dot(e, f), -5.0f);
+}
+
+// -----------------------------------------------------------------------------
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Add templated Vector class and dot() utility function

- Implemented generic cgl::Vector<N, T> supporting basic arithmetic operators (+, -, *, /)
- Added type aliases for Vec2f/Vec3f/Vec4f and Point variants
- Introduced templated dot() function for N-dimensional vectors